### PR TITLE
Add call center setup scripts

### DIFF
--- a/call-center/server/scripts/prestart.js
+++ b/call-center/server/scripts/prestart.js
@@ -1,0 +1,24 @@
+/* Run configs before each startup */
+const telnyx = require('telnyx')(process.env.TELNYX_API_KEY);
+
+async function prestart() {
+  if (!process.env.NGROK_SUBDOMAIN) {
+    return;
+  }
+
+  try {
+    const {
+      data: callControlApp,
+    } = await telnyx.callControlApplications.retrieve(
+      process.env.TELNYX_CC_APP_ID
+    );
+
+    await callControlApp.update({
+      webhook_event_url: `https://${process.env.NGROK_SUBDOMAIN}.ngrok.io/calls/callbacks/call-control-app`,
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+prestart();

--- a/call-center/server/scripts/setup.js
+++ b/call-center/server/scripts/setup.js
@@ -1,0 +1,103 @@
+/* Set up your application */
+const fs = require('fs');
+const telnyx = require('telnyx')(process.env.TELNYX_API_KEY);
+
+async function setup() {
+  if (!process.env.NGROK_SUBDOMAIN) {
+    console.log('No ngrok subdomain specified, not continuing with setup');
+    return;
+  }
+
+  let appName = process.env.APP_NAME || 'Sample - Call Center App';
+  let callControlId = process.env.TELNYX_CC_APP_ID;
+
+  if (!callControlId) {
+    try {
+      const {
+        data: callControlApp,
+      } = await telnyx.callControlApplications.create({
+        application_name: appName,
+        webhook_event_url: `https://${process.env.NGROK_SUBDOMAIN}.ngrok.io/calls/callbacks/call-control-app`,
+        webhook_api_version: '2',
+        // Hangup after default timeout of 30 seconds
+        // Prevents long calls during development
+        first_command_timeout: true,
+      });
+
+      await fs.appendFile(
+        './.env',
+        `TELNYX_CC_APP_ID=${callControlApp.id}`,
+        'utf8',
+        (err) => {
+          if (err) {
+            console.log(err);
+          } else {
+            console.log(
+              `Telnyx Call Control App "${appName}" successfully created`
+            );
+          }
+        }
+      );
+
+      callControlId = callControlApp.id;
+    } catch (err) {
+      console.log(err);
+
+      if (err.raw && err.raw.errors) {
+        console.log('Server error:', err.raw.errors[0]);
+      }
+    }
+  }
+
+  let phoneNumber = process.env.TELNYX_SIP_OB_NUMBER;
+
+  if (!phoneNumber) {
+    console.log(
+      'No phone number specified, buy a phone number in portal.telnyx.com and manually add your call control application'
+    );
+  } else {
+    let phoneNumberId;
+
+    try {
+      let { data: phoneNumbers } = await telnyx.phoneNumbers.list({
+        filter: { phone_number: phoneNumber },
+        page: {
+          number: 1,
+          size: 1,
+        },
+      });
+
+      phoneNumberId = phoneNumbers[0].id;
+    } catch (err) {
+      console.error(err);
+
+      if (err.raw && err.raw.errors) {
+        console.log('Server error:', err.raw.errors[0]);
+      }
+    }
+
+    if (phoneNumberId) {
+      try {
+        const { data: phoneNumber } = await telnyx.phoneNumbers.update(
+          phoneNumberId,
+          {
+            connection_id: callControlId,
+            tags: ['Development'],
+          }
+        );
+
+        console.log(
+          'Successfully assigned call control application to phone number'
+        );
+      } catch (err) {
+        console.error(err);
+
+        if (err.raw && err.raw.errors) {
+          console.log('Server error:', err.raw.errors[0]);
+        }
+      }
+    }
+  }
+}
+
+setup();

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 // import { State } from '@telnyx/webrtc/lib/Modules/Verto/webrtc/constants';
 import { invite, transfer } from '../services/callsService';
+import IAgent from '../interfaces/IAgent';
 import Agents from './Agents';
 import './ActiveCall.css';
 
@@ -16,6 +17,7 @@ interface IActiveCall {
   hangup: Function;
   muteAudio: Function;
   unmuteAudio: Function;
+  agents?: IAgent[];
 }
 
 function ActiveCall({
@@ -28,6 +30,7 @@ function ActiveCall({
   hangup,
   muteAudio,
   unmuteAudio,
+  agents,
 }: IActiveCall) {
   console.log('callState:', callState);
   const [isMuted, setIsMuted] = useState(false);
@@ -45,16 +48,16 @@ function ActiveCall({
     setIsMuted(false);
   };
 
-  const addAgent = (agentToAdd: any) =>
+  const addToCall = (destination: string) =>
     invite({
       inviterSipUsername: sipUsername,
-      to: `sip:${agentToAdd.sipUsername}@sip.telnyx.com`,
+      to: destination,
     });
 
-  const transferToAgent = (agentToTransfer: any) =>
+  const transferCall = (destination: string) =>
     transfer({
       transfererSipUsername: sipUsername,
-      to: `sip:${agentToTransfer.sipUsername}@sip.telnyx.com`,
+      to: destination,
     });
 
   const isIncoming = callDirection === 'inbound';
@@ -141,9 +144,9 @@ function ActiveCall({
       )}
       <section className="App-section">
         <Agents
-          sipUsername={sipUsername}
-          addAgent={addAgent}
-          transferToAgent={transferToAgent}
+          agents={agents}
+          addToCall={addToCall}
+          transferCall={transferCall}
         />
       </section>
       {/* TODO Conference calls with multiple agents */}

--- a/call-center/web-client/src/components/Agents/index.tsx
+++ b/call-center/web-client/src/components/Agents/index.tsx
@@ -1,60 +1,37 @@
 import React, { useEffect, useState } from 'react';
-import './styles.css';
-import { getLoggedInAgents } from '../../services/agentsService';
 import IAgent from '../../interfaces/IAgent';
-import LoadingIcon from '../LoadingIcon';
-import useInterval from '../../hooks/useInterval';
+import './styles.css';
 
 interface IAgents {
-  sipUsername: string;
-  addAgent?: Function;
-  transferToAgent?: Function;
+  agents?: IAgent[];
+  addToCall?: Function;
+  transferCall?: Function;
 }
 
-export default function Agents({
-  sipUsername,
-  addAgent,
-  transferToAgent,
-}: IAgents) {
-  let [loading, setLoading] = useState<boolean>(true);
-  let [error, setError] = useState<string | undefined>();
-  let [agents, setAgents] = useState<IAgent[] | undefined>();
-
-  function loadLoggedInAgents() {
-    setLoading(true);
-
-    return getLoggedInAgents()
-      .then((res) => {
-        let otherAgents = res.data.agents.filter(
-          (agent) => agent.sipUsername !== sipUsername
-        );
-
-        setAgents(otherAgents);
-      })
-      .catch((error) => {
-        setError(error.toString());
-      })
-      .finally(() => setLoading(false));
+export default function Agents({ agents, addToCall, transferCall }: IAgents) {
+  function addAgent(agent: IAgent) {
+    if (addToCall) {
+      return addToCall(`sip:${agent.sipUsername}@sip.telnyx.com`);
+    }
   }
 
-  useInterval(loadLoggedInAgents, 5000);
+  function transferToAgent(agent: IAgent) {
+    if (transferCall) {
+      return transferCall(`sip:${agent.sipUsername}@sip.telnyx.com`);
+    }
+  }
 
   return (
     <div className="Agents">
-      <h2 className="Agents-heading">
-        Other agents {loading && <LoadingIcon />}
-      </h2>
-
-      {error && <p className="Agents-error">Error: {error}</p>}
       {agents && agents.length > 0 && (
         <ul className="Agents-list">
           {agents.map((agent) => (
             <li key={agent.id} className="Agents-list-item">
               <div>{agent.name}</div>
 
-              {(addAgent || transferToAgent) && (
+              {(addToCall || transferCall) && (
                 <div className="Agents-list-actions">
-                  {addAgent && agent.available && (
+                  {addToCall && agent.available && (
                     <button
                       type="button"
                       className="App-button App-button--small App-button--primary"
@@ -64,7 +41,7 @@ export default function Agents({
                     </button>
                   )}
 
-                  {transferToAgent && agent.available && (
+                  {transferCall && agent.available && (
                     <button
                       type="button"
                       className="App-button App-button--small App-button--secondary"
@@ -74,7 +51,7 @@ export default function Agents({
                     </button>
                   )}
 
-                  {(addAgent || transferToAgent) && !agent.available && (
+                  {(addToCall || transferCall) && !agent.available && (
                     <div className="Agents-list-label Agents-list-label--busy">
                       Busy
                     </div>
@@ -82,7 +59,7 @@ export default function Agents({
                 </div>
               )}
 
-              {!addAgent && !transferToAgent && (
+              {!addToCall && !transferCall && (
                 <div className="Agents-list-actions">
                   <div
                     className={`Agents-list-label Agents-list-label--${

--- a/call-center/web-client/src/components/Agents/styles.css
+++ b/call-center/web-client/src/components/Agents/styles.css
@@ -1,18 +1,3 @@
-.Agents {
-}
-
-.Agents-heading {
-  font-size: 2rem;
-  font-weight: normal;
-  line-height: 1;
-  margin-top: 0;
-  margin-bottom: 1.5rem;
-}
-
-.Agents-error {
-  text-color: red;
-}
-
 .Agents-list {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Low priority suggested changes. Adds setup and prestart scripts, aimed towards internal use only for now. I wanted to reduce my dependency on the portal during development.

These changes do not include any documentation updates.

## ✋ Manual testing

### Prestart script
Only relevant if you're on the free version of ngrok: restart your ngrok server so that you receive a new forwarding URL. Start the call center app with `NGROK_SUBDOMAIN={your subdomain} npm start`. Verify update in [the portal](https://portal.telnyx.com/#/app/call-control/applications). Verify app functions as expected.

### Setup script
Remove `TELNYX_CC_APP_ID` from `.env`. Run `NGROK_SUBDOMAIN={your subdomain} node -r dotenv/config ./scripts/setup.js`. Verify that a call control application has been created in [the portal](https://portal.telnyx.com/#/app/call-control/applications) and that your phone number is assigned to it.