### PR TITLE
Remove conference participant

### DIFF
--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -139,7 +139,7 @@ class CallsController {
 
     try {
       let callLegRepository = getManager().getRepository(CallLeg);
-      let appCallLegToHangUp = await callLegRepository.findOneOrFail({
+      let appCall = await callLegRepository.findOneOrFail({
         where: {
           status: CallLegStatus.ACTIVE,
           to: participant,
@@ -148,15 +148,15 @@ class CallsController {
 
       // Create a new Telnyx Call in order to issue call control commands
       // to the call leg to hang up
-      let transfererCall = new telnyx.Call({
-        call_control_id: appCallLegToHangUp.telnyxCallControlId,
+      let telnyxCall = new telnyx.Call({
+        call_control_id: appCall.telnyxCallControlId,
       });
 
       // Hang up the call
-      await transfererCall.hangup();
+      await telnyxCall.hangup();
 
       res.json({
-        data: appCallLegToHangUp,
+        data: appCall,
       });
     } catch (e) {
       console.error(e);

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -132,6 +132,40 @@ class CallsController {
         .send({ error: e });
     }
   };
+  // Hang up a call by the specified destination, e.g. to remove a number
+  // from a conference call
+  public static hangup = async function (req: Request, res: Response) {
+    let { participant } = req.body;
+
+    try {
+      let callLegRepository = getManager().getRepository(CallLeg);
+      let appCallLegToHangUp = await callLegRepository.findOneOrFail({
+        where: {
+          status: CallLegStatus.ACTIVE,
+          to: participant,
+        },
+      });
+
+      // Create a new Telnyx Call in order to issue call control commands
+      // to the call leg to hang up
+      let transfererCall = new telnyx.Call({
+        call_control_id: appCallLegToHangUp.telnyxCallControlId,
+      });
+
+      // Hang up the call
+      await transfererCall.hangup();
+
+      res.json({
+        data: appCallLegToHangUp,
+      });
+    } catch (e) {
+      console.error(e);
+
+      res
+        .status(e && e.name === 'EntityNotFound' ? 404 : 500)
+        .send({ error: e });
+    }
+  };
 
   /*
    * Directs the call flow based on the Call Control event type

--- a/call-center/server/routes/calls.ts
+++ b/call-center/server/routes/calls.ts
@@ -7,6 +7,7 @@ let router = express.Router();
 router.post('/actions/bridge', CallsController.bridge);
 router.post('/actions/conferences/invite', CallsController.invite);
 router.post('/actions/conferences/transfer', CallsController.transfer);
+router.post('/actions/conferences/hangup', CallsController.hangup);
 
 // Callbacks
 router.post('/callbacks/call-control-app', CallsController.callControl);

--- a/call-center/web-client/src/components/ActiveCall.css
+++ b/call-center/web-client/src/components/ActiveCall.css
@@ -34,6 +34,11 @@
   margin: 1rem 0;
 }
 
+.ActiveCall-participant-row {
+  display: grid;
+  grid-template-columns: 1fr max-content;
+}
+
 .ActiveCall-participant {
   font-size: 30px;
   font-weight: bold;

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -135,15 +135,17 @@ function ActiveCallConference({
             ) : null}
             <span className="ActiveCall-participant-name">{displayName}</span>
           </div>
-          <div>
-            <button
-              type="button"
-              className="App-button App-button--small App-button--danger"
-              onClick={() => confirmRemove(participant)}
-            >
-              Remove
-            </button>
-          </div>
+          {index !== 0 && (
+            <div>
+              <button
+                type="button"
+                className="App-button App-button--small App-button--danger"
+                onClick={() => confirmRemove(participant)}
+              >
+                Remove
+              </button>
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -5,7 +5,10 @@ import IAgent from '../interfaces/IAgent';
 import Agents from './Agents';
 import './ActiveCall.css';
 import useInterval from '../hooks/useInterval';
-import { getConference } from '../services/conferencesService';
+import {
+  getConference,
+  removeFromConference,
+} from '../services/conferencesService';
 import IConference from '../interfaces/IConference';
 import { CallLegDirection, CallLegStatus } from '../interfaces/ICallLeg';
 
@@ -187,9 +190,8 @@ function ActiveCall({
       to: destination,
     });
 
-  const removeFromCall = (participant: string) => {
-    console.log('TODO remove:', participant);
-  };
+  const removeFromCall = (participant: string) =>
+    removeFromConference(participant);
 
   const isIncoming = callDirection === 'inbound';
   const isRinging = callState === 'ringing';

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -95,12 +95,35 @@ function ActiveCallConference({
     }
   }, [conference, sipUsername]);
 
+  const confirmRemove = (participant: string) => {
+    let result = window.confirm(
+      `Are you sure you want to remove ${participant} from this call?`
+    );
+
+    if (result) {
+      // TODO
+    }
+  };
+
   return (
     <div className="ActiveCall-conference">
       {conferenceParticipants.map((participant, index) => (
-        <div className="ActiveCall-participant">
-          {index !== 0 ? <span className="ActiveCall-ampersand">&</span> : null}
-          <span className="ActiveCall-participant-name">{participant}</span>
+        <div className="ActiveCall-participant-row">
+          <div className="ActiveCall-participant">
+            {index !== 0 ? (
+              <span className="ActiveCall-ampersand">&</span>
+            ) : null}
+            <span className="ActiveCall-participant-name">{participant}</span>
+          </div>
+          <div>
+            <button
+              type="button"
+              className="App-button App-button--small App-button--danger"
+              onClick={() => confirmRemove(participant)}
+            >
+              Remove
+            </button>
+          </div>
         </div>
       ))}
     </div>

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -11,6 +11,10 @@ interface ITransferAgentParams {
   to: string;
 }
 
+interface IHangupParams {
+  participant: string;
+}
+
 export const invite = async (
   params: IInviteAgentParams
 ): Promise<AxiosResponse | AxiosError> => {
@@ -29,6 +33,19 @@ export const transfer = async (
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/transfer`, params, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    .then((resp: AxiosResponse) => resp)
+    .catch((error: AxiosError) => error);
+};
+
+export const hangup = async (
+  params: IHangupParams
+): Promise<AxiosResponse | AxiosError> => {
+  return await axios
+    .post(`${BASE_URL}/calls/actions/conferences/hangup`, params, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/call-center/web-client/src/services/conferencesService.ts
+++ b/call-center/web-client/src/services/conferencesService.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import IConference from '../interfaces/IConference';
 import { BASE_URL } from '../configs/constants';
+import { hangup } from './callsService';
 
 export const getConference = async (
   id: string
@@ -10,4 +11,9 @@ export const getConference = async (
       'Content-Type': 'application/json',
     },
   });
+};
+
+export const removeFromConference = async (participant: string) => {
+  // Hanging up the call leg is the same removing from the conference
+  return hangup({ participant });
 };


### PR DESCRIPTION
Removes any conference participant from the call.

## ✋ Manual testing

1. Run call-center app and log in as two agents
2. Call your call center phone number and pick up as one agent. Add the other agent to the call. Verify that you see the "Remove" button next to invited agent
3. Pick up as the invited agent and then remove the agent. Verify that you see a confirmation popup
4. Click "OK". Verify that the call for the added agent hangs up

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots

<img width="624" alt="Screen Shot 2020-10-01 at 3 33 27 PM" src="https://user-images.githubusercontent.com/4672952/94870229-e941a480-03fb-11eb-8fda-b8b829fae3bf.png">

<img width="600" alt="Screen Shot 2020-10-01 at 3 33 43 PM" src="https://user-images.githubusercontent.com/4672952/94870257-f9598400-03fb-11eb-8796-c1ec53877f45.png">
