### PR TITLE
fix: update TypeScript version to support testing-library types pretty-format

### DIFF
--- a/call-center/web-client/package-lock.json
+++ b/call-center/web-client/package-lock.json
@@ -13082,9 +13082,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/call-center/web-client/package.json
+++ b/call-center/web-client/package.json
@@ -16,7 +16,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.3",
-    "typescript": "^3.7.5"
+    "typescript": "^4.0.3"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Upgrade the TypeScript version to fix the following error when try to start the application

![image](https://user-images.githubusercontent.com/16343871/95499270-709e9300-097b-11eb-85f5-088eddcc8d9a.png)


## ✋ Manual testing

1. navigate into `call-center/web-client`
2. run `npm i` && `npm start`
3. See if build correctly.

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots
![image](https://user-images.githubusercontent.com/16343871/95499474-b22f3e00-097b-11eb-978b-cf25326442de.png)
