### PR TITLE
feat(WEBRTC-190): update telnyx webrtc version to fix hang up many times error

### DIFF
--- a/call-center/web-client/package-lock.json
+++ b/call-center/web-client/package-lock.json
@@ -1531,9 +1531,9 @@
       }
     },
     "@telnyx/webrtc": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@telnyx/webrtc/-/webrtc-2.1.5.tgz",
-      "integrity": "sha512-dGdvY06ewczvi+HqBlOdTG9DYA5Gv3zuAyu8b7VLAchSmmYeO9voR3n7jxw6kE5VuMVoh2SiL/cDZ2OFJyc0Zg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@telnyx/webrtc/-/webrtc-2.1.6.tgz",
+      "integrity": "sha512-FfJj9kiXGfZwWXluWDixA8N4lBZpX25pgDsYBncojBdviAgs65rpYO18TcB8FNNvqOnzWT7V+2kv5sDwBay72Q==",
       "requires": {
         "loglevel": "^1.6.8",
         "uuid": "^7.0.3"

--- a/call-center/web-client/package.json
+++ b/call-center/web-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@telnyx/webrtc": "^2.1.5",
+    "@telnyx/webrtc": "^2.1.6",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^10.4.9",
     "@testing-library/user-event": "^7.2.1",


### PR DESCRIPTION
- Update `telnyx webrtc` version to fix hang up many times error

## ✋ Manual testing

1. navigate into `call-center`
2. run `npm install` && `npm start`
3. Login 
4. Call from a webdialer to your call control number 
5. When the call arrives in the `call center app` click in hang up.
6. Check with you only needed to click once to hang up. 

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots