### PR TITLE
Test calls routes

### DIFF
--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -1,17 +1,24 @@
+const mockAnswer = jest.fn();
+const mockHangup = jest.fn();
+const mockMute = jest.fn();
+const mockUnmute = jest.fn();
+
 class Call {
-  answer = () => {};
+  answer = mockAnswer;
+  hangup = mockHangup;
 }
 
 class Conference {
-  unmute = () => {};
-  mute = () => {};
+  mute = mockMute;
+  unmute = mockUnmute;
 }
 
-const telnyx = {
+module.exports = jest.fn().mockImplementation(() => ({
   Call,
   Conference,
-};
+}));
 
-module.exports = function () {
-  return telnyx;
-};
+module.exports.mockAnswer = mockAnswer;
+module.exports.mockHangup = mockHangup;
+module.exports.mockMute = mockMute;
+module.exports.mockUnmute = mockUnmute;

--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -1,0 +1,11 @@
+class Call {
+  answer = () => {};
+}
+
+const telnyx = {
+  Call,
+};
+
+module.exports = function () {
+  return telnyx;
+};

--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -2,8 +2,14 @@ class Call {
   answer = () => {};
 }
 
+class Conference {
+  unmute = () => {};
+  mute = () => {};
+}
+
 const telnyx = {
   Call,
+  Conference,
 };
 
 module.exports = function () {

--- a/call-center/server/fixtures/CallLeg.yml
+++ b/call-center/server/fixtures/CallLeg.yml
@@ -4,7 +4,7 @@ items:
     id: callLeg1
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
+    to: 'sip:callLeg1@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId1'
     telnyxConnectionId: 'telnyxConnectionId1'
@@ -14,17 +14,17 @@ items:
     id: callLeg2
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
+    to: 'sip:callLeg2@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId2'
     telnyxConnectionId: 'telnyxConnectionId2'
-    muted: false
+    muted: true
     conference: '@conference2'
   callLeg3:
     id: callLeg3
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
+    to: 'sip:callLeg3@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId3'
     telnyxConnectionId: 'telnyxConnectionId3'
@@ -34,7 +34,7 @@ items:
     id: callLeg4
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
+    to: 'sip:callLeg4@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId4'
     telnyxConnectionId: 'telnyxConnectionId4'

--- a/call-center/server/fixtures/CallLeg.yml
+++ b/call-center/server/fixtures/CallLeg.yml
@@ -1,0 +1,42 @@
+entity: CallLeg
+items:
+  callLeg1:
+    id: callLeg1
+    status: 'active'
+    from: '{{phone.phoneNumber}}'
+    to: '{{phone.phoneNumber}}'
+    direction: 'incoming'
+    telnyxCallControlId: 'telnyxCallControlId1'
+    telnyxConnectionId: 'telnyxConnectionId1'
+    muted: false
+    conference: '@conference1'
+  callLeg2:
+    id: callLeg2
+    status: 'active'
+    from: '{{phone.phoneNumber}}'
+    to: '{{phone.phoneNumber}}'
+    direction: 'incoming'
+    telnyxCallControlId: 'telnyxCallControlId2'
+    telnyxConnectionId: 'telnyxConnectionId2'
+    muted: false
+    conference: '@conference2'
+  callLeg3:
+    id: callLeg3
+    status: 'active'
+    from: '{{phone.phoneNumber}}'
+    to: '{{phone.phoneNumber}}'
+    direction: 'incoming'
+    telnyxCallControlId: 'telnyxCallControlId3'
+    telnyxConnectionId: 'telnyxConnectionId3'
+    muted: false
+    conference: '@conference2'
+  callLeg4:
+    id: callLeg4
+    status: 'active'
+    from: '{{phone.phoneNumber}}'
+    to: '{{phone.phoneNumber}}'
+    direction: 'incoming'
+    telnyxCallControlId: 'telnyxCallControlId4'
+    telnyxConnectionId: 'telnyxConnectionId4'
+    muted: false
+    conference: '@conference2'

--- a/call-center/server/fixtures/Conference.yml
+++ b/call-center/server/fixtures/Conference.yml
@@ -1,0 +1,10 @@
+entity: Conference
+items:
+  conference1:
+    id: conference1
+    from: '{{phone.phoneNumber}}'
+    telnyxConferenceId: 'telnyxConference1'
+  conference2:
+    id: conference2
+    from: '{{phone.phoneNumber}}'
+    telnyxConferenceId: 'telnyxConference2'

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -2,27 +2,7 @@ import { getManager } from 'typeorm';
 import { CallLeg } from '../entities/callLeg.entity';
 import TestFactory from '../TestFactory';
 
-const telnyxPackage = require('telnyx');
-
-const mockAnswer = jest.fn();
-const mockHangup = jest.fn();
-const mockMute = jest.fn();
-const mockUnmute = jest.fn();
-
-jest.mock('telnyx', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      Call: function Call() {
-        this.answer = mockAnswer;
-        this.hangup = mockHangup;
-      },
-      Conference: function Conference() {
-        this.mute = mockMute;
-        this.unmute = mockUnmute;
-      },
-    };
-  });
-});
+const telnyxMock = require('telnyx');
 
 const testFactory = new TestFactory();
 
@@ -32,44 +12,14 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  telnyxPackage.mockClear();
+  telnyxMock.mockClear();
 });
 
 afterAll(async () => {
   await testFactory.close();
 });
 
-test('POST /actions/bridge', () =>
-  testFactory.app
-    .post('/calls/actions/bridge')
-    .send({})
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then((resp) => {
-      expect(resp.body).toBeDefined();
-    }));
-
-test('POST /actions/conferences/invite', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/invite')
-    .send({})
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then((resp) => {
-      expect(resp.body).toBeDefined();
-    }));
-
-test('POST /actions/conferences/transfer', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/transfer')
-    .send({})
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then((resp) => {
-      expect(resp.body).toBeDefined();
-    }));
-
-test.only('POST /actions/conferences/hangup', () =>
+test('POST /actions/conferences/hangup', () =>
   testFactory.app
     .post('/calls/actions/conferences/hangup')
     .send({
@@ -78,7 +28,7 @@ test.only('POST /actions/conferences/hangup', () =>
     .expect('Content-type', /json/)
     .expect(200)
     .then(() => {
-      expect(mockHangup).toHaveBeenCalled();
+      expect(telnyxMock.mockHangup).toHaveBeenCalled();
     }));
 
 test('POST /actions/conferences/mute', () =>
@@ -95,7 +45,7 @@ test('POST /actions/conferences/mute', () =>
         .findOne('callLeg2');
 
       expect(callLeg?.muted).toEqual(true);
-      expect(mockMute).toHaveBeenCalled();
+      expect(telnyxMock.mockMute).toHaveBeenCalled();
     }));
 
 test('POST /actions/conferences/unmute', () =>
@@ -112,7 +62,7 @@ test('POST /actions/conferences/unmute', () =>
         .findOne('callLeg2');
 
       expect(callLeg?.muted).toEqual(false);
-      expect(mockUnmute).toHaveBeenCalled();
+      expect(telnyxMock.mockUnmute).toHaveBeenCalled();
     }));
 
 test('POST /callbacks/call-control-app', () =>
@@ -145,5 +95,5 @@ test('POST /callbacks/call-control-app', () =>
       });
 
       expect(callLeg).toBeDefined();
-      expect(mockAnswer).toHaveBeenCalled();
+      expect(telnyxMock.mockAnswer).toHaveBeenCalled();
     }));

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -1,0 +1,108 @@
+import { getManager } from 'typeorm';
+import { CallLeg } from '../entities/callLeg.entity';
+import TestFactory from '../TestFactory';
+
+const telnyxPackage = require('telnyx');
+
+const testFactory = new TestFactory();
+
+beforeAll(async () => {
+  await testFactory.init();
+  await testFactory.loadFixtures();
+});
+
+afterAll(async () => {
+  await testFactory.close();
+});
+
+test('POST /actions/bridge', () =>
+  testFactory.app
+    .post('/calls/actions/bridge')
+    .send({})
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body).toBeDefined();
+    }));
+
+test('POST /actions/conferences/invite', () =>
+  testFactory.app
+    .post('/calls/actions/conferences/invite')
+    .send({})
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body).toBeDefined();
+    }));
+
+test('POST /actions/conferences/transfer', () =>
+  testFactory.app
+    .post('/calls/actions/conferences/transfer')
+    .send({})
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body).toBeDefined();
+    }));
+
+test('POST /actions/conferences/hangup', () =>
+  testFactory.app
+    .post('/calls/actions/conferences/hangup')
+    .send({})
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body).toBeDefined();
+    }));
+
+test('POST /actions/conferences/mute', () =>
+  testFactory.app
+    .post('/calls/actions/conferences/mute')
+    .send({})
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body).toBeDefined();
+    }));
+
+test('POST /actions/conferences/unmute', () =>
+  testFactory.app
+    .post('/calls/actions/conferences/unmute')
+    .send({})
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body).toBeDefined();
+    }));
+
+test.only('POST /callbacks/call-control-app', () =>
+  testFactory.app
+    .post('/calls/callbacks/call-control-app')
+    .send({
+      data: {
+        event_type: 'call.initiated',
+        payload: {
+          state: 'parked',
+          client_state: null,
+          call_control_id: 'fake_call_control_id',
+          connection_id: 'fake_connection_id',
+          from: 'fake_from',
+          to: 'fake_to',
+          direction: 'incoming',
+        },
+      },
+    })
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then(async () => {
+      const callLeg = await getManager().getRepository(CallLeg).findOne({
+        from: 'fake_from',
+        to: 'fake_to',
+        direction: 'incoming',
+        telnyxCallControlId: 'fake_call_control_id',
+        telnyxConnectionId: 'fake_connection_id',
+        muted: false,
+      });
+
+      expect(callLeg).toBeDefined();
+    }));

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -5,6 +5,7 @@ import TestFactory from '../TestFactory';
 const telnyxPackage = require('telnyx');
 
 const mockAnswer = jest.fn();
+const mockHangup = jest.fn();
 const mockMute = jest.fn();
 const mockUnmute = jest.fn();
 
@@ -13,6 +14,7 @@ jest.mock('telnyx', () => {
     return {
       Call: function Call() {
         this.answer = mockAnswer;
+        this.hangup = mockHangup;
       },
       Conference: function Conference() {
         this.mute = mockMute;
@@ -67,14 +69,16 @@ test('POST /actions/conferences/transfer', () =>
       expect(resp.body).toBeDefined();
     }));
 
-test('POST /actions/conferences/hangup', () =>
+test.only('POST /actions/conferences/hangup', () =>
   testFactory.app
     .post('/calls/actions/conferences/hangup')
-    .send({})
+    .send({
+      participant: 'sip:callLeg1@sip.telnyx.com',
+    })
     .expect('Content-type', /json/)
     .expect(200)
-    .then((resp) => {
-      expect(resp.body).toBeDefined();
+    .then(() => {
+      expect(mockHangup).toHaveBeenCalled();
     }));
 
 test('POST /actions/conferences/mute', () =>
@@ -94,7 +98,7 @@ test('POST /actions/conferences/mute', () =>
       expect(mockMute).toHaveBeenCalled();
     }));
 
-test.only('POST /actions/conferences/unmute', () =>
+test('POST /actions/conferences/unmute', () =>
   testFactory.app
     .post('/calls/actions/conferences/unmute')
     .send({
@@ -111,7 +115,7 @@ test.only('POST /actions/conferences/unmute', () =>
       expect(mockUnmute).toHaveBeenCalled();
     }));
 
-test.only('POST /callbacks/call-control-app', () =>
+test('POST /callbacks/call-control-app', () =>
   testFactory.app
     .post('/calls/callbacks/call-control-app')
     .send({


### PR DESCRIPTION
Adds tests for hangup, mute, unmute and call control. Other public routes depend on agents fixtures to be complete: https://github.com/team-telnyx/telnyx-client-examples/pull/42

## ✋ Manual testing

Run `npm test` in `call-center/server`. Verify that tests pass

## 📸 Screenshots

<img width="362" alt="Screen Shot 2020-10-08 at 1 40 42 PM" src="https://user-images.githubusercontent.com/4672952/95511138-e4d13a80-096b-11eb-98e7-a9b0b366566f.png">
