### PR TITLE
Add conference tests

### DIFF
--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -1,24 +1,33 @@
-const mockAnswer = jest.fn();
-const mockHangup = jest.fn();
-const mockMute = jest.fn();
-const mockUnmute = jest.fn();
+const callMock = {
+  answer: jest.fn(),
+  hangup: jest.fn(),
+  bridge: jest.fn(),
+};
+
+const conferenceMock = {
+  mute: jest.fn(),
+  unmute: jest.fn(),
+};
 
 class Call {
-  answer = mockAnswer;
-  hangup = mockHangup;
+  answer = callMock.answer;
+  hangup = callMock.hangup;
 }
 
 class Conference {
-  mute = mockMute;
-  unmute = mockUnmute;
+  mute = conferenceMock.mute;
+  unmute = conferenceMock.unmute;
 }
 
 module.exports = jest.fn().mockImplementation(() => ({
   Call,
   Conference,
+  calls: {
+    create: () => ({
+      bridge: callMock.bridge,
+    }),
+  },
 }));
 
-module.exports.mockAnswer = mockAnswer;
-module.exports.mockHangup = mockHangup;
-module.exports.mockMute = mockMute;
-module.exports.mockUnmute = mockUnmute;
+module.exports.callMock = callMock;
+module.exports.conferenceMock = conferenceMock;

--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -9,6 +9,13 @@ const conferenceMock = {
   unmute: jest.fn(),
 };
 
+const callsCreateMock = jest.fn().mockImplementation(() => ({
+  ...callMock,
+  data: {
+    call_control_id: 'fake_call_control_id',
+  },
+}));
+
 class Call {
   answer = callMock.answer;
   hangup = callMock.hangup;
@@ -23,11 +30,10 @@ module.exports = jest.fn().mockImplementation(() => ({
   Call,
   Conference,
   calls: {
-    create: () => ({
-      bridge: callMock.bridge,
-    }),
+    create: callsCreateMock,
   },
 }));
 
 module.exports.callMock = callMock;
 module.exports.conferenceMock = conferenceMock;
+module.exports.callsCreateMock = callsCreateMock;

--- a/call-center/server/fixtures/Agent.yml
+++ b/call-center/server/fixtures/Agent.yml
@@ -3,18 +3,18 @@ items:
   agent1:
     id: agent1
     name: '{{name.firstName}} {{name.lastName}}'
-    sipUsername: '{{internet.userName}}'
+    sipUsername: 'agent1SipUsername'
     loggedIn: true
     available: true
   agent2:
     id: agent2
     name: '{{name.firstName}} {{name.lastName}}'
-    sipUsername: '{{internet.userName}}'
+    sipUsername: 'agent2SipUsername'
     loggedIn: true
     available: true
   agent3:
     id: agent3
     name: '{{name.firstName}} {{name.lastName}}'
-    sipUsername: '{{internet.userName}}'
+    sipUsername: 'agent3SipUsername'
     loggedIn: true
     available: false

--- a/call-center/server/fixtures/CallLeg.yml
+++ b/call-center/server/fixtures/CallLeg.yml
@@ -4,7 +4,7 @@ items:
     id: callLeg1
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: 'sip:callLeg1@sip.telnyx.com'
+    to: 'sip:agent1SipUsername@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId1'
     telnyxConnectionId: 'telnyxConnectionId1'
@@ -14,7 +14,7 @@ items:
     id: callLeg2
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: 'sip:callLeg2@sip.telnyx.com'
+    to: '{{phone.phoneNumber}}'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId2'
     telnyxConnectionId: 'telnyxConnectionId2'
@@ -24,7 +24,7 @@ items:
     id: callLeg3
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: 'sip:callLeg3@sip.telnyx.com'
+    to: '{{phone.phoneNumber}}'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId3'
     telnyxConnectionId: 'telnyxConnectionId3'
@@ -34,7 +34,7 @@ items:
     id: callLeg4
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: 'sip:callLeg4@sip.telnyx.com'
+    to: '{{phone.phoneNumber}}'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId4'
     telnyxConnectionId: 'telnyxConnectionId4'

--- a/call-center/server/fixtures/CallLeg.yml
+++ b/call-center/server/fixtures/CallLeg.yml
@@ -14,7 +14,7 @@ items:
     id: callLeg2
     status: 'active'
     from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
+    to: 'sip:agent2SipUsername@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId2'
     telnyxConnectionId: 'telnyxConnectionId2'

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -19,6 +19,21 @@ afterAll(async () => {
   await testFactory.close();
 });
 
+test('POST /actions/bridge', () =>
+  testFactory.app
+    .post('/calls/actions/bridge')
+    .send({
+      data: {
+        call_control_id: 'fake_call_control_id',
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      },
+    })
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then(() => {
+      expect(telnyxMock.callMock.bridge).toHaveBeenCalled();
+    }));
+
 test('POST /actions/conferences/hangup', () =>
   testFactory.app
     .post('/calls/actions/conferences/hangup')
@@ -28,7 +43,7 @@ test('POST /actions/conferences/hangup', () =>
     .expect('Content-type', /json/)
     .expect(200)
     .then(() => {
-      expect(telnyxMock.mockHangup).toHaveBeenCalled();
+      expect(telnyxMock.callMock.hangup).toHaveBeenCalled();
     }));
 
 test('POST /actions/conferences/mute', () =>
@@ -45,7 +60,7 @@ test('POST /actions/conferences/mute', () =>
         .findOne('callLeg2');
 
       expect(callLeg?.muted).toEqual(true);
-      expect(telnyxMock.mockMute).toHaveBeenCalled();
+      expect(telnyxMock.conferenceMock.mute).toHaveBeenCalled();
     }));
 
 test('POST /actions/conferences/unmute', () =>
@@ -62,7 +77,7 @@ test('POST /actions/conferences/unmute', () =>
         .findOne('callLeg2');
 
       expect(callLeg?.muted).toEqual(false);
-      expect(telnyxMock.mockUnmute).toHaveBeenCalled();
+      expect(telnyxMock.conferenceMock.unmute).toHaveBeenCalled();
     }));
 
 test('POST /callbacks/call-control-app', () =>
@@ -95,5 +110,5 @@ test('POST /callbacks/call-control-app', () =>
       });
 
       expect(callLeg).toBeDefined();
-      expect(telnyxMock.mockAnswer).toHaveBeenCalled();
+      expect(telnyxMock.callMock.answer).toHaveBeenCalled();
     }));

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -65,8 +65,6 @@ test('POST /actions/invite', () =>
           relations: ['conference'],
         });
 
-      console.log(callLeg);
-
       expect(callLeg).toBeDefined();
       expect(callLeg?.conference?.id).toEqual('conference1');
       expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
@@ -101,8 +99,6 @@ test('POST /actions/transfer', () =>
           },
           relations: ['conference'],
         });
-
-      console.log(callLeg);
 
       expect(callLeg).toBeDefined();
       expect(callLeg?.conference?.id).toEqual('conference1');

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -19,7 +19,7 @@ afterAll(async () => {
   await testFactory.close();
 });
 
-test('POST /actions/bridge', () =>
+test.only('POST /actions/bridge', () =>
   testFactory.app
     .post('/calls/actions/bridge')
     .send({
@@ -31,7 +31,51 @@ test('POST /actions/bridge', () =>
     .expect('Content-type', /json/)
     .expect(200)
     .then(() => {
+      expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: process.env.TELNYX_SIP_OB_NUMBER,
+          to: 'sip:agent3SipUsername@sip.telnyx.com',
+          connection_id: process.env.TELNYX_SIP_CONNECTION_ID,
+        })
+      );
       expect(telnyxMock.callMock.bridge).toHaveBeenCalled();
+    }));
+
+test.only('POST /actions/invite', () =>
+  testFactory.app
+    .post('/calls/actions/conferences/invite')
+    .send({
+      inviterSipUsername: 'agent1SipUsername',
+      to: 'sip:agent2SipUsername@sip.telnyx.com',
+    })
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then(async () => {
+      const callLeg = await getManager()
+        .getRepository(CallLeg)
+        .findOne({
+          where: {
+            from: process.env.TELNYX_SIP_OB_NUMBER,
+            to: 'sip:agent2SipUsername@sip.telnyx.com',
+            direction: 'outgoing',
+            telnyxCallControlId: 'fake_call_control_id',
+            telnyxConnectionId: 'telnyxConnectionId1',
+            muted: false,
+          },
+          relations: ['conference'],
+        });
+
+      console.log(callLeg);
+
+      expect(callLeg).toBeDefined();
+      expect(callLeg?.conference?.id).toEqual('conference1');
+      expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: process.env.TELNYX_SIP_OB_NUMBER,
+          to: 'sip:agent2SipUsername@sip.telnyx.com',
+          connection_id: 'telnyxConnectionId1',
+        })
+      );
     }));
 
 test('POST /actions/conferences/hangup', () =>

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -46,7 +46,7 @@ test('POST /actions/invite', () =>
     .post('/calls/actions/conferences/invite')
     .send({
       inviterSipUsername: 'agent1SipUsername',
-      to: 'sip:agent2SipUsername@sip.telnyx.com',
+      to: 'sip:agent3SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)
     .expect(200)
@@ -56,7 +56,7 @@ test('POST /actions/invite', () =>
         .findOne({
           where: {
             from: process.env.TELNYX_SIP_OB_NUMBER,
-            to: 'sip:agent2SipUsername@sip.telnyx.com',
+            to: 'sip:agent3SipUsername@sip.telnyx.com',
             direction: 'outgoing',
             telnyxCallControlId: 'fake_call_control_id',
             telnyxConnectionId: 'telnyxConnectionId1',
@@ -72,7 +72,7 @@ test('POST /actions/invite', () =>
       expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
         expect.objectContaining({
           from: process.env.TELNYX_SIP_OB_NUMBER,
-          to: 'sip:agent2SipUsername@sip.telnyx.com',
+          to: 'sip:agent3SipUsername@sip.telnyx.com',
           connection_id: 'telnyxConnectionId1',
         })
       );
@@ -83,7 +83,7 @@ test('POST /actions/transfer', () =>
     .post('/calls/actions/conferences/transfer')
     .send({
       transfererSipUsername: 'agent1SipUsername',
-      to: 'sip:agent2SipUsername@sip.telnyx.com',
+      to: 'sip:agent3SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)
     .expect(200)
@@ -93,7 +93,7 @@ test('POST /actions/transfer', () =>
         .findOne({
           where: {
             from: process.env.TELNYX_SIP_OB_NUMBER,
-            to: 'sip:agent2SipUsername@sip.telnyx.com',
+            to: 'sip:agent3SipUsername@sip.telnyx.com',
             direction: 'outgoing',
             telnyxCallControlId: 'fake_call_control_id',
             telnyxConnectionId: 'telnyxConnectionId1',
@@ -109,7 +109,7 @@ test('POST /actions/transfer', () =>
       expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
         expect.objectContaining({
           from: process.env.TELNYX_SIP_OB_NUMBER,
-          to: 'sip:agent2SipUsername@sip.telnyx.com',
+          to: 'sip:agent3SipUsername@sip.telnyx.com',
           connection_id: 'telnyxConnectionId1',
         })
       );
@@ -121,7 +121,7 @@ test('POST /actions/conferences/hangup', () =>
   testFactory.app
     .post('/calls/actions/conferences/hangup')
     .send({
-      participant: 'sip:callLeg1@sip.telnyx.com',
+      participant: 'sip:agent1SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)
     .expect(200)
@@ -133,7 +133,7 @@ test('POST /actions/conferences/mute', () =>
   testFactory.app
     .post('/calls/actions/conferences/mute')
     .send({
-      participant: 'sip:callLeg1@sip.telnyx.com',
+      participant: 'sip:agent1SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)
     .expect(200)
@@ -150,7 +150,7 @@ test('POST /actions/conferences/unmute', () =>
   testFactory.app
     .post('/calls/actions/conferences/unmute')
     .send({
-      participant: 'sip:callLeg2@sip.telnyx.com',
+      participant: 'sip:agent2SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)
     .expect(200)

--- a/call-center/server/routes/conferences.test.ts
+++ b/call-center/server/routes/conferences.test.ts
@@ -1,0 +1,31 @@
+import { getManager } from 'typeorm';
+import { CallLeg } from '../entities/callLeg.entity';
+import TestFactory from '../TestFactory';
+
+const telnyxMock = require('telnyx');
+
+const testFactory = new TestFactory();
+
+beforeAll(async () => {
+  await testFactory.init();
+  await testFactory.loadFixtures();
+});
+
+beforeEach(() => {
+  telnyxMock.mockClear();
+});
+
+afterAll(async () => {
+  await testFactory.close();
+});
+
+test('GET /:id_or_sip_address', () =>
+  testFactory.app
+    .get('/conferences/conference1')
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then((resp) => {
+      expect(resp.body.conference).toMatchObject({
+        id: 'conference1',
+      });
+    }));


### PR DESCRIPTION
Adds additional server tests around calls and conferences.

## ✋ Manual testing

Run `npm test` from `call-center/server`. Verify tests pass

## 📸 Screenshots

<img width="238" alt="Screen Shot 2020-10-08 at 3 23 55 PM" src="https://user-images.githubusercontent.com/4672952/95519620-4ef0dc00-097a-11eb-939c-c341c9ba2f1d.png">
