### PR TITLE
Refactor outgoing call flow

### DIFF
--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -5,6 +5,7 @@ const callMock = {
 };
 
 const conferenceMock = {
+  join: jest.fn(),
   mute: jest.fn(),
   unmute: jest.fn(),
 };
@@ -31,6 +32,7 @@ class Call {
 class Conference {
   mute = conferenceMock.mute;
   unmute = conferenceMock.unmute;
+  join = conferenceMock.join;
 }
 
 module.exports = jest.fn().mockImplementation(() => ({

--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -5,7 +5,6 @@ const callMock = {
 };
 
 const conferenceMock = {
-  join: jest.fn(),
   mute: jest.fn(),
   unmute: jest.fn(),
 };
@@ -32,7 +31,6 @@ class Call {
 class Conference {
   mute = conferenceMock.mute;
   unmute = conferenceMock.unmute;
-  join = conferenceMock.join;
 }
 
 module.exports = jest.fn().mockImplementation(() => ({

--- a/call-center/server/__mocks__/telnyx.ts
+++ b/call-center/server/__mocks__/telnyx.ts
@@ -16,6 +16,13 @@ const callsCreateMock = jest.fn().mockImplementation(() => ({
   },
 }));
 
+const conferencesCreateMock = jest.fn().mockImplementation(() => ({
+  ...conferenceMock,
+  data: {
+    id: 'fake_conference_id',
+  },
+}));
+
 class Call {
   answer = callMock.answer;
   hangup = callMock.hangup;
@@ -32,8 +39,12 @@ module.exports = jest.fn().mockImplementation(() => ({
   calls: {
     create: callsCreateMock,
   },
+  conferences: {
+    create: conferencesCreateMock,
+  },
 }));
 
 module.exports.callMock = callMock;
 module.exports.conferenceMock = conferenceMock;
 module.exports.callsCreateMock = callsCreateMock;
+module.exports.conferencesCreateMock = conferencesCreateMock;

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -502,14 +502,14 @@ class CallsController {
 
 // The Telnyx Call Control API expects the client state to be
 // base64 encoded, so we have our encode/decode helpers here
-function encodeClientState(data: IClientState) {
+export function encodeClientState(data: IClientState) {
   let jsonStr = JSON.stringify(data);
   let buffer = Buffer.from(jsonStr);
 
   return buffer.toString('base64');
 }
 
-function decodeClientState(data?: string): Partial<IClientState> {
+export function decodeClientState(data?: string): Partial<IClientState> {
   if (!data) return {};
 
   let buffer = Buffer.from(data, 'base64');

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -411,9 +411,8 @@ class CallsController {
                 telnyxCallControlId: call_control_id,
               });
               appIncomingCallLeg.status = CallLegStatus.ACTIVE;
-              appConference.callLegs = [appIncomingCallLeg];
-
-              await conferenceRepository.save(appConference);
+              appIncomingCallLeg.conference = appConference;
+              await callLegRepository.save(appIncomingCallLeg);
 
               // Call the agent to invite them to join the conference call
               let appOutgoingCall = await CallsController.createCall({
@@ -450,10 +449,7 @@ class CallsController {
 
             if (clientState.appConferenceId) {
               let appConference = await conferenceRepository.findOneOrFail(
-                clientState.appConferenceId,
-                {
-                  relations: ['callLegs'],
-                }
+                clientState.appConferenceId
               );
 
               // Join the conference with the original caller

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -70,7 +70,7 @@ class CallsController {
 
       // Call the agent to invite them to join the conference call
       res.json({
-        data: await CallsController.dial({
+        data: await CallsController.createCall({
           to,
           from,
           connectionId: appInviterCallLeg.telnyxConnectionId,
@@ -110,7 +110,7 @@ class CallsController {
       let from = process.env.TELNYX_SIP_OB_NUMBER || '';
 
       // Call the agent to invite them to join the conference call
-      let newAgentDial = await CallsController.dial({
+      let newAgentDial = await CallsController.createCall({
         to,
         from,
         connectionId: appTransfererCallLeg.telnyxConnectionId,
@@ -335,14 +335,14 @@ class CallsController {
 
             if (availableAgent) {
               // Create a new Telnyx Conference to organize & issue commands
-              // to multiple call legs at once
+              // to multiple call legs at once and save it to our DB
               let appConference = await CallsController.createConference({
                 from,
                 callControlId: call_control_id,
               });
 
               // Call the agent to invite them to join the conference call
-              await CallsController.dial({
+              await CallsController.createCall({
                 to: `sip:${availableAgent.sipUsername}@sip.telnyx.com`,
                 from,
                 connectionId: connection_id,
@@ -463,7 +463,7 @@ class CallsController {
     return await conferenceRepository.save(appConference);
   };
 
-  private static dial = async function ({
+  private static createCall = async function ({
     from,
     to,
     connectionId,

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -71,9 +71,6 @@ class CallsController {
         from,
         callControlId: appOutgoingCall.telnyxCallControlId,
       });
-
-      // Add agent to call
-      appOutgoingCall.callControlAgentSipUsername = callerSipUsername;
       // Add outgoing call to conference
       appOutgoingCall.conference = appConference;
       await callLegRepository.save(appOutgoingCall);
@@ -103,7 +100,7 @@ class CallsController {
       let appInviterCallLeg = await callLegRepository.findOneOrFail({
         where: {
           status: CallLegStatus.ACTIVE,
-          callControlAgentSipUsername: inviterSipUsername,
+          to: `sip:${inviterSipUsername}@sip.telnyx.com`,
         },
         relations: ['conference'],
       });
@@ -154,7 +151,7 @@ class CallsController {
       let appTransfererCallLeg = await callLegRepository.findOneOrFail({
         where: {
           status: CallLegStatus.ACTIVE,
-          callControlAgentSipUsername: transfererSipUsername,
+          to: `sip:${transfererSipUsername}@sip.telnyx.com`,
         },
         relations: ['conference'],
       });
@@ -368,7 +365,6 @@ class CallsController {
             appIncomingCallLeg.direction = CallLegDirection.INCOMING;
             appIncomingCallLeg.telnyxCallControlId = call_control_id;
             appIncomingCallLeg.telnyxConnectionId = connection_id;
-            appIncomingCallLeg.callControlAgentSipUsername = '';
             appIncomingCallLeg.muted = false;
 
             await callLegRepository.save(appIncomingCallLeg);
@@ -429,9 +425,6 @@ class CallsController {
                 }),
               });
 
-              // Add agent to call
-              appOutgoingCall.callControlAgentSipUsername =
-                availableAgent.sipUsername;
               // Add outgoing call to conference
               appOutgoingCall.conference = appConference;
               await callLegRepository.save(appOutgoingCall);
@@ -588,7 +581,6 @@ class CallsController {
     appOutgoingCall.status = CallLegStatus.ACTIVE;
     appOutgoingCall.telnyxCallControlId = telnyxOutgoingCall.call_control_id;
     appOutgoingCall.telnyxConnectionId = connectionId;
-    appOutgoingCall.callControlAgentSipUsername = '';
     appOutgoingCall.muted = false;
 
     return await callLegRepository.save(appOutgoingCall);

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -364,6 +364,7 @@ class CallsController {
             appIncomingCallLeg.direction = CallLegDirection.INCOMING;
             appIncomingCallLeg.telnyxCallControlId = call_control_id;
             appIncomingCallLeg.telnyxConnectionId = connection_id;
+            appIncomingCallLeg.callControlAgentSipUsername = '';
             appIncomingCallLeg.muted = false;
 
             await callLegRepository.save(appIncomingCallLeg);
@@ -563,16 +564,17 @@ class CallsController {
     });
 
     // Save newly created leg to our database
-    let appAgentCallLeg = new CallLeg();
-    appAgentCallLeg.to = to;
-    appAgentCallLeg.from = from;
-    appAgentCallLeg.direction = CallLegDirection.OUTGOING;
-    appAgentCallLeg.status = CallLegStatus.ACTIVE;
-    appAgentCallLeg.telnyxCallControlId = telnyxOutgoingCall.call_control_id;
-    appAgentCallLeg.telnyxConnectionId = connectionId;
-    appAgentCallLeg.muted = false;
+    let appOutgoingCall = new CallLeg();
+    appOutgoingCall.to = to;
+    appOutgoingCall.from = from;
+    appOutgoingCall.direction = CallLegDirection.OUTGOING;
+    appOutgoingCall.status = CallLegStatus.ACTIVE;
+    appOutgoingCall.telnyxCallControlId = telnyxOutgoingCall.call_control_id;
+    appOutgoingCall.telnyxConnectionId = connectionId;
+    appOutgoingCall.callControlAgentSipUsername = '';
+    appOutgoingCall.muted = false;
 
-    return await callLegRepository.save(appAgentCallLeg);
+    return await callLegRepository.save(appOutgoingCall);
   };
 
   private static getAvailableAgent = async function () {

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -49,7 +49,7 @@ class CallsController {
 
   // Make an outbound call
   public static dial = async function (req: Request, res: Response) {
-    let { to } = req.body;
+    let { callerSipUsername, to } = req.body;
 
     try {
       let callLegRepository = getManager().getRepository(CallLeg);
@@ -72,6 +72,8 @@ class CallsController {
         callControlId: appOutgoingCall.telnyxCallControlId,
       });
 
+      // Add agent to call
+      appOutgoingCall.callControlAgentSipUsername = callerSipUsername;
       // Add outgoing call to conference
       appOutgoingCall.conference = appConference;
       await callLegRepository.save(appOutgoingCall);

--- a/call-center/server/entities/callLeg.entity.ts
+++ b/call-center/server/entities/callLeg.entity.ts
@@ -43,6 +43,9 @@ export class CallLeg {
   telnyxConnectionId!: string;
 
   @Column()
+  callControlAgentSipUsername!: string;
+
+  @Column()
   muted!: boolean;
 
   @ManyToOne((type) => Conference, (conference) => conference.callLegs, {

--- a/call-center/server/entities/callLeg.entity.ts
+++ b/call-center/server/entities/callLeg.entity.ts
@@ -43,9 +43,6 @@ export class CallLeg {
   telnyxConnectionId!: string;
 
   @Column()
-  callControlAgentSipUsername!: string;
-
-  @Column()
   muted!: boolean;
 
   @ManyToOne((type) => Conference, (conference) => conference.callLegs, {

--- a/call-center/server/fixtures/CallLeg.yml
+++ b/call-center/server/fixtures/CallLeg.yml
@@ -9,7 +9,6 @@ items:
     telnyxCallControlId: 'telnyxCallControlId1'
     telnyxConnectionId: 'telnyxConnectionId1'
     muted: false
-    callControlAgentSipUsername: 'agent1SipUsername'
     conference: '@conference1'
   callLeg2:
     id: callLeg2
@@ -20,7 +19,6 @@ items:
     telnyxCallControlId: 'telnyxCallControlId2'
     telnyxConnectionId: 'telnyxConnectionId2'
     muted: true
-    callControlAgentSipUsername: 'agent2SipUsername'
     conference: '@conference2'
   callLeg3:
     id: callLeg3
@@ -31,7 +29,6 @@ items:
     telnyxCallControlId: 'telnyxCallControlId3'
     telnyxConnectionId: 'telnyxConnectionId3'
     muted: false
-    callControlAgentSipUsername: 'agent1SipUsername'
     conference: '@conference2'
   callLeg4:
     id: callLeg4
@@ -42,5 +39,4 @@ items:
     telnyxCallControlId: 'telnyxCallControlId4'
     telnyxConnectionId: 'telnyxConnectionId4'
     muted: false
-    callControlAgentSipUsername: ''
     conference: '@conference2'

--- a/call-center/server/fixtures/CallLeg.yml
+++ b/call-center/server/fixtures/CallLeg.yml
@@ -9,6 +9,7 @@ items:
     telnyxCallControlId: 'telnyxCallControlId1'
     telnyxConnectionId: 'telnyxConnectionId1'
     muted: false
+    callControlAgentSipUsername: 'agent1SipUsername'
     conference: '@conference1'
   callLeg2:
     id: callLeg2
@@ -19,24 +20,27 @@ items:
     telnyxCallControlId: 'telnyxCallControlId2'
     telnyxConnectionId: 'telnyxConnectionId2'
     muted: true
+    callControlAgentSipUsername: 'agent2SipUsername'
     conference: '@conference2'
   callLeg3:
     id: callLeg3
     status: 'active'
-    from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
+    from: 'sip:agent1SipUsername@sip.telnyx.com'
+    to: 'sip:agent2SipUsername@sip.telnyx.com'
     direction: 'incoming'
     telnyxCallControlId: 'telnyxCallControlId3'
     telnyxConnectionId: 'telnyxConnectionId3'
     muted: false
+    callControlAgentSipUsername: 'agent1SipUsername'
     conference: '@conference2'
   callLeg4:
     id: callLeg4
     status: 'active'
-    from: '{{phone.phoneNumber}}'
-    to: '{{phone.phoneNumber}}'
-    direction: 'incoming'
+    from: 'sip:agent1SipUsername@sip.telnyx.com'
+    to: 'sip:agent2SipUsername@sip.telnyx.com'
+    direction: 'outgoing'
     telnyxCallControlId: 'telnyxCallControlId4'
     telnyxConnectionId: 'telnyxConnectionId4'
     muted: false
+    callControlAgentSipUsername: ''
     conference: '@conference2'

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -273,6 +273,7 @@ test('POST /callbacks/call-control-app | call.answered | client_state.answer_inc
           telnyxCallControlId: 'telnyxCallControlId1',
           telnyxConnectionId: 'telnyxConnectionId1',
           status: 'active',
+          callControlAgentSipUsername: 'agent1SipUsername',
         })
       );
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -10,10 +10,11 @@ const testFactory = new TestFactory();
 
 beforeAll(async () => {
   await testFactory.init();
-  await testFactory.loadFixtures();
 });
 
-beforeEach(() => {
+beforeEach(async () => {
+  await testFactory.clear();
+  await testFactory.loadFixtures();
   telnyxMock.mockClear();
 });
 
@@ -48,6 +49,7 @@ test('POST /actions/dial', () =>
     .post('/calls/actions/dial')
     .send({
       to: '+15551231234',
+      callerSipUsername: 'agent1SipUsername',
     })
     .expect('Content-type', /json/)
     .expect(200)
@@ -71,6 +73,7 @@ test('POST /actions/dial', () =>
           telnyxConnectionId: process.env.TELNYX_SIP_CONNECTION_ID,
           status: 'active',
           muted: false,
+          callControlAgentSipUsername: 'agent1SipUsername',
         }),
       ]);
       expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -238,7 +238,7 @@ test('POST /callbacks/call-control-app | call.answered | client_state.answer_inc
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
     }));
 
-test('POST /callbacks/call-control-app | call.answered | client_state.dial_agent', () =>
+test('POST /callbacks/call-control-app | call.answered | client_state.dial', () =>
   testFactory.app
     .post('/calls/callbacks/call-control-app')
     .send({
@@ -246,7 +246,7 @@ test('POST /callbacks/call-control-app | call.answered | client_state.dial_agent
         event_type: 'call.answered',
         payload: {
           client_state: encodeClientState({
-            appCallState: 'dial_agent',
+            appCallState: 'dial',
             appConferenceId: 'conference1',
           }),
           call_control_id: 'telnyxCallControlId1',

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -73,7 +73,6 @@ test('POST /actions/dial', () =>
           telnyxConnectionId: process.env.TELNYX_SIP_CONNECTION_ID,
           status: 'active',
           muted: false,
-          callControlAgentSipUsername: 'agent1SipUsername',
         }),
       ]);
       expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
@@ -276,7 +275,6 @@ test('POST /callbacks/call-control-app | call.answered | client_state.answer_inc
           telnyxCallControlId: 'telnyxCallControlId1',
           telnyxConnectionId: 'telnyxConnectionId1',
           status: 'active',
-          callControlAgentSipUsername: 'agent1SipUsername',
         })
       );
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -81,10 +81,6 @@ test('POST /actions/dial', () =>
         })
       );
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
-      expect(telnyxMock.conferenceMock.join).toHaveBeenCalledWith({
-        call_control_id: 'fake_call_control_id',
-        start_conference_on_enter: true,
-      });
     }));
 
 test('POST /actions/invite', () =>
@@ -282,7 +278,7 @@ test('POST /callbacks/call-control-app | call.answered | client_state.answer_inc
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
     }));
 
-test('POST /callbacks/call-control-app | call.answered | client_state.dial', () =>
+test('POST /callbacks/call-control-app | call.answered | client_state.dial_agent', () =>
   testFactory.app
     .post('/calls/callbacks/call-control-app')
     .send({
@@ -290,7 +286,7 @@ test('POST /callbacks/call-control-app | call.answered | client_state.dial', () 
         event_type: 'call.answered',
         payload: {
           client_state: encodeClientState({
-            appCallState: 'dial',
+            appCallState: 'dial_agent',
             appConferenceId: 'conference1',
           }),
           call_control_id: 'telnyxCallControlId1',

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -194,7 +194,7 @@ test('POST /callbacks/call-control-app | call.initiated', () =>
       expect(telnyxMock.callMock.answer).toHaveBeenCalled();
     }));
 
-test('POST /callbacks/call-control-app | call.answered', () =>
+test('POST /callbacks/call-control-app | call.answered | client_state.answer_incoming_parked', () =>
   testFactory.app
     .post('/calls/callbacks/call-control-app')
     .send({
@@ -236,4 +236,32 @@ test('POST /callbacks/call-control-app | call.answered', () =>
         })
       );
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
+    }));
+
+test('POST /callbacks/call-control-app | call.answered | client_state.dial_agent', () =>
+  testFactory.app
+    .post('/calls/callbacks/call-control-app')
+    .send({
+      data: {
+        event_type: 'call.answered',
+        payload: {
+          client_state: encodeClientState({
+            appCallState: 'dial_agent',
+            appConferenceId: 'conference1',
+          }),
+          call_control_id: 'telnyxCallControlId1',
+          connection_id: 'telnyxConnectionId1',
+          from: 'fake_from',
+          to: 'sip:agent1SipUsername@sip.telnyx.com',
+          direction: 'incoming',
+        },
+      },
+    })
+    .expect('Content-type', /json/)
+    .expect(200)
+    .then(() => {
+      expect(telnyxMock.conferenceMock.join).toHaveBeenCalledWith({
+        call_control_id: 'telnyxCallControlId1',
+        start_conference_on_enter: true,
+      });
     }));

--- a/call-center/server/routes/calls.ts
+++ b/call-center/server/routes/calls.ts
@@ -5,6 +5,7 @@ let router = express.Router();
 
 // Actions
 router.post('/actions/bridge', CallsController.bridge);
+router.post('/actions/dial', CallsController.dial);
 router.post('/actions/conferences/invite', CallsController.invite);
 router.post('/actions/conferences/transfer', CallsController.transfer);
 router.post('/actions/conferences/hangup', CallsController.hangup);


### PR DESCRIPTION
Backend changes to fix the outgoing call flow. Untested in the browser, unit tests pass.

Main changes:
- Renamed private `.dial` -> private `.createCall`
- Added public `.dial`

TODO Manual testing in the browser once UI update is complete.

## ✋ Manual testing

Run `npm test -- -i routes/calls.test.ts` in `call-center/server`. Verify that tests pass

## 📸 Screenshots

<img width="397" alt="Screen Shot 2020-10-13 at 9 40 47 AM" src="https://user-images.githubusercontent.com/4672952/95890127-34cb4b00-0d38-11eb-8501-314523a4388f.png">
