### PR TITLE
Prepare for dial using call control

### DIFF
--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -63,7 +63,7 @@ class CallsController {
       let appOutgoingCall = await CallsController.createCall({
         to,
         from,
-        connectionId: process.env.TELNYX_SIP_CONNECTION_ID!,
+        connectionId: process.env.TELNYX_CC_APP_ID!,
       });
 
       // Create new conference

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -56,7 +56,7 @@ class CallsController {
 
       // NOTE Specifying the host SIP username doesn't seem to work,
       // possibly because connection ID relationship?
-      // let from = `sip:${inviterSipUsername}@sip.telnyx.com`;
+      // let from = `sip:${initiatorSipUsername}@sip.telnyx.com`;
       let from = process.env.TELNYX_SIP_OB_NUMBER!;
 
       // Create outgoing call
@@ -89,7 +89,7 @@ class CallsController {
 
   // Invite an agent or phone number to join another agent's conference call
   public static invite = async function (req: Request, res: Response) {
-    let { inviterSipUsername, to } = req.body;
+    let { initiatorSipUsername, to } = req.body;
 
     try {
       // Find the correct call leg and conference by inviter's SIP username
@@ -100,14 +100,14 @@ class CallsController {
       let appInviterCallLeg = await callLegRepository.findOneOrFail({
         where: {
           status: CallLegStatus.ACTIVE,
-          to: `sip:${inviterSipUsername}@sip.telnyx.com`,
+          to: `sip:${initiatorSipUsername}@sip.telnyx.com`,
         },
         relations: ['conference'],
       });
 
       // NOTE Specifying the host SIP username doesn't seem to work,
       // possibly because connection ID relationship?
-      // let from = `sip:${inviterSipUsername}@sip.telnyx.com`;
+      // let from = `sip:${initiatorSipUsername}@sip.telnyx.com`;
       let from = process.env.TELNYX_SIP_OB_NUMBER!;
 
       // Call someone to invite them to join the conference call
@@ -140,7 +140,7 @@ class CallsController {
 
   // Transfer the call to an agent or phone number to join
   public static transfer = async function (req: Request, res: Response) {
-    let { transfererSipUsername, to } = req.body;
+    let { initiatorSipUsername, to } = req.body;
 
     try {
       // Find the correct call leg and conference by transferer's SIP username
@@ -151,14 +151,14 @@ class CallsController {
       let appTransfererCallLeg = await callLegRepository.findOneOrFail({
         where: {
           status: CallLegStatus.ACTIVE,
-          to: `sip:${transfererSipUsername}@sip.telnyx.com`,
+          to: `sip:${initiatorSipUsername}@sip.telnyx.com`,
         },
         relations: ['conference'],
       });
 
       // NOTE Specifying the host SIP username doesn't seem to work,
       // possibly because connection ID relationship?
-      // let from = `sip:${transfererSipUsername}@sip.telnyx.com`;
+      // let from = `sip:${initiatorSipUsername}@sip.telnyx.com`;
       let from = process.env.TELNYX_SIP_OB_NUMBER!;
 
       // Call someone to invite them to join the conference call

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -89,7 +89,7 @@ test('POST /actions/invite', () =>
   testFactory.app
     .post('/calls/actions/conferences/invite')
     .send({
-      inviterSipUsername: 'agent1SipUsername',
+      initiatorSipUsername: 'agent1SipUsername',
       to: 'sip:agent3SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)
@@ -124,7 +124,7 @@ test('POST /actions/transfer', () =>
   testFactory.app
     .post('/calls/actions/conferences/transfer')
     .send({
-      transfererSipUsername: 'agent1SipUsername',
+      initiatorSipUsername: 'agent1SipUsername',
       to: 'sip:agent3SipUsername@sip.telnyx.com',
     })
     .expect('Content-type', /json/)

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -70,7 +70,7 @@ test('POST /actions/dial', () =>
           to: '+15551231234',
           direction: 'outgoing',
           telnyxCallControlId: 'fake_call_control_id',
-          telnyxConnectionId: process.env.TELNYX_SIP_CONNECTION_ID,
+          telnyxConnectionId: process.env.TELNYX_CC_APP_ID,
           status: 'active',
           muted: false,
         }),
@@ -79,7 +79,7 @@ test('POST /actions/dial', () =>
         expect.objectContaining({
           from: process.env.TELNYX_SIP_OB_NUMBER,
           to: '+15551231234',
-          connection_id: process.env.TELNYX_SIP_CONNECTION_ID,
+          connection_id: process.env.TELNYX_CC_APP_ID,
         })
       );
       expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -115,13 +115,13 @@ function ActiveCallConference({
 
   const addToCall = (destination: string) =>
     invite({
-      inviterSipUsername: sipUsername,
+      initiatorSipUsername: sipUsername,
       to: destination,
     });
 
   const transferCall = (destination: string) =>
     transfer({
-      transfererSipUsername: sipUsername,
+      initiatorSipUsername: sipUsername,
       to: destination,
     });
 

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -2,13 +2,8 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import ICallLeg from '../interfaces/ICallLeg';
 import { BASE_URL } from '../configs/constants';
 
-interface IInviteAgentParams {
-  inviterSipUsername: string;
-  to: string;
-}
-
-interface ITransferAgentParams {
-  transfererSipUsername: string;
+interface ICallActionsParams {
+  initiatorSipUsername: string;
   to: string;
 }
 
@@ -20,8 +15,21 @@ interface IConferenceActionsResponse {
   data: ICallLeg;
 }
 
+export const dial = async (
+  params: ICallActionsParams
+): Promise<AxiosResponse | AxiosError> => {
+  return await axios
+    .post(`${BASE_URL}/calls/actions/dial`, params, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    .then((resp: AxiosResponse) => resp)
+    .catch((error: AxiosError) => error);
+};
+
 export const invite = async (
-  params: IInviteAgentParams
+  params: ICallActionsParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/invite`, params, {
@@ -34,7 +42,7 @@ export const invite = async (
 };
 
 export const transfer = async (
-  params: ITransferAgentParams
+  params: ICallActionsParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/transfer`, params, {


### PR DESCRIPTION
Normalize and fix call service params to prepare for server dial.

TODO Server dial implementation

## ✋ Manual testing

Run the call-center app and make a call. App should function as expected.

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots