### PR TITLE
Upgrade WebRTC SDK version to 2.2.0

### DIFF
--- a/call-center/web-client/package-lock.json
+++ b/call-center/web-client/package-lock.json
@@ -1531,9 +1531,9 @@
       }
     },
     "@telnyx/webrtc": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@telnyx/webrtc/-/webrtc-2.1.6.tgz",
-      "integrity": "sha512-FfJj9kiXGfZwWXluWDixA8N4lBZpX25pgDsYBncojBdviAgs65rpYO18TcB8FNNvqOnzWT7V+2kv5sDwBay72Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@telnyx/webrtc/-/webrtc-2.2.0.tgz",
+      "integrity": "sha512-e7tgo983TZAn4hfsEnZ4MSc0w3D7gz3gno7dNNdcyJUlE5WjtZAuJdwXOgJogwBwAu2OvZ8gP+YP+GCgoIleIA==",
       "requires": {
         "loglevel": "^1.6.8",
         "uuid": "^7.0.3"

--- a/call-center/web-client/package.json
+++ b/call-center/web-client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@telnyx/webrtc": "^2.1.6",
+    "@telnyx/webrtc": "^2.2.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^10.4.9",
     "@testing-library/user-event": "^7.2.1",


### PR DESCRIPTION
Upgrades Telnyx WebRTC SDK version in order to receive Telnyx call IDs in the notification event payload.

## ✋ Manual testing

Open browser dev tools. Run the call-center app and make an incoming call.
- Verify app functions as expected
- Verify that `telnyxCallControlId`, `telnyxLegId` and `telnyxSessionId` is present in `{event}.options`

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [x] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots

Notification payload:
<img width="585" alt="Screen Shot 2020-10-21 at 10 11 53 AM" src="https://user-images.githubusercontent.com/4672952/96754369-0f68bd80-1386-11eb-9de1-0a6d4ef848ba.png">
