### PR TITLE
Refactor web client answer

### DIFF
--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -309,13 +309,13 @@ function ActiveCall({
     setIsMuted(false);
   };
 
-  const isIncoming = !isDialing && callDirection === 'inbound';
+  const isIncoming = callDirection === 'inbound';
   const isRinging = callState === 'ringing';
   const isActive = callState === 'active';
 
   return (
     <section>
-      {isIncoming && isRinging && (
+      {!isDialing && isRinging && (
         <div className="App-section">
           <div>Incoming call</div>
           <div className="ActiveCall-callerId">{callerId}</div>
@@ -339,23 +339,7 @@ function ActiveCall({
           </div>
         </div>
       )}
-      {isDialing && (
-        <div className="App-section">
-          <div>Calling...</div>
-          {/* TODO Get final destination number */}
-          <div className="ActiveCall-callerId">{callDestination}</div>
-          <div className="ActiveCall-actions">
-            <button
-              type="button"
-              className="App-button App-button--small App-button--danger"
-              onClick={handleHangupClick}
-            >
-              Hangup
-            </button>
-          </div>
-        </div>
-      )}
-      {isActive && (
+      {(isDialing || isActive) && (
         <div className="App-section">
           <div>Call in progress</div>
           <ActiveCallConference

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -22,6 +22,7 @@ interface IActiveCall {
   // FIXME `IWebRTCCall.state` needs to be updated to be `State`
   // callState: State;
   callState: string;
+  isDialing: boolean;
   answer: Function;
   hangup: Function;
   muteAudio: Function;
@@ -286,12 +287,12 @@ function ActiveCall({
   callDestination,
   callerId,
   callState,
+  isDialing,
   answer,
   hangup,
   muteAudio,
   unmuteAudio,
 }: IActiveCall) {
-  console.log('callState:', callState);
   const [isMuted, setIsMuted] = useState(false);
 
   const handleAnswerClick = () => answer();
@@ -308,18 +309,13 @@ function ActiveCall({
     setIsMuted(false);
   };
 
-  const isIncoming = callDirection === 'inbound';
+  const isIncoming = !isDialing && callDirection === 'inbound';
   const isRinging = callState === 'ringing';
-  const isCalling =
-    (!isIncoming && callState === 'new') ||
-    callState === 'requesting' ||
-    callState === 'trying' ||
-    callState === 'early';
   const isActive = callState === 'active';
 
   return (
     <section>
-      {isRinging && (
+      {isIncoming && isRinging && (
         <div className="App-section">
           <div>Incoming call</div>
           <div className="ActiveCall-callerId">{callerId}</div>
@@ -343,9 +339,10 @@ function ActiveCall({
           </div>
         </div>
       )}
-      {isCalling && (
+      {isDialing && (
         <div className="App-section">
           <div>Calling...</div>
+          {/* TODO Get final destination number */}
           <div className="ActiveCall-callerId">{callDestination}</div>
           <div className="ActiveCall-actions">
             <button

--- a/call-center/web-client/src/components/Common/index.tsx
+++ b/call-center/web-client/src/components/Common/index.tsx
@@ -26,6 +26,7 @@ interface IPartialWebRTCCall {
     remoteCallerName: string;
     remoteCallerNumber: string;
     destinationNumber: string;
+    telnyxCallControlId: string;
   };
   answer: Function;
   hangup: Function;
@@ -140,16 +141,18 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
   useEffect(() => {
     if (!webRTCall) return;
 
-    const { state, answer } = webRTCall;
+    const { state, answer, options } = webRTCall;
 
     if (isDialInitiated) {
       if (state === 'new') {
-        // Immediately answer
+        // Check if call should be answered automatically, such as in
+        // the case when the agent has initiated an outgoing call:
+        // when an agent dials a number, the call is routed through
+        // the call center app, a conference is created, and both the
+        // agent and external number is invited to the conference.
         callsService
-          .get({
-            // TODO Use `telnyx_session_id`
-            // once https://github.com/team-telnyx/webrtc/pull/46 is published
-            to: `sip:${agentSipUsername}@sip.telnyx.com`,
+          .getCall({
+            telnyxCallControlId: options.telnyxCallControlId,
             limit: 1,
           })
           .then(({ data }) => {

--- a/call-center/web-client/src/components/Common/index.tsx
+++ b/call-center/web-client/src/components/Common/index.tsx
@@ -43,7 +43,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
   // Check if component is mounted before updating state
   // in the Telnyx WebRTC client callbacks
   let isMountedRef = useRef<boolean>(false);
-  let [isDialInitiated, setIsDialInitiated] = useState<boolean>(false);
+  let [isDialing, setIsDialing] = useState<boolean>(false);
   let [webRTCClientState, setWebRTCClientState] = useState<string>('');
   let [webRTCall, setWebRTCCall] = useState<IPartialWebRTCCall | null>();
   let agentsState = useAgents(agentSipUsername);
@@ -143,7 +143,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
 
     const { state, answer, options } = webRTCall;
 
-    if (isDialInitiated) {
+    if (isDialing) {
       if (state === 'new') {
         // Check if call should be answered automatically, such as in
         // the case when the agent has initiated an outgoing call:
@@ -162,15 +162,12 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
             ) {
               answer();
             }
-          })
-          .finally(() => {
-            setIsDialInitiated(false);
           });
-      } else {
-        setIsDialInitiated(false);
+      } else if (state === 'active') {
+        setIsDialing(false);
       }
     }
-  }, [isDialInitiated, webRTCall]);
+  }, [isDialing, webRTCall]);
 
   const dial = useCallback(
     (destination) => {
@@ -179,7 +176,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
         to: destination,
       };
 
-      setIsDialInitiated(true);
+      setIsDialing(true);
 
       callsService.dial(dialParams);
     },
@@ -217,6 +214,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
             webRTCall.options.remoteCallerNumber
           }
           callState={webRTCall.state}
+          isDialing={isDialing}
           answer={webRTCall.answer}
           hangup={webRTCall.hangup}
           muteAudio={webRTCall.muteAudio}

--- a/call-center/web-client/src/components/Common/index.tsx
+++ b/call-center/web-client/src/components/Common/index.tsx
@@ -151,7 +151,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
         // the call center app, a conference is created, and both the
         // agent and external number is invited to the conference.
         callsService
-          .getCall({
+          .get({
             telnyxCallControlId: options.telnyxCallControlId,
             limit: 1,
           })

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -19,7 +19,7 @@ interface IConferenceActionsResponse {
   data: ICallLeg;
 }
 
-export const getCall = async (
+export const get = async (
   params: Partial<ICallLeg & IFindManyParams>
 ): Promise<AxiosResponse<{ calls: ICallLeg[] }>> => {
   return await axios.get(`${BASE_URL}/calls/`, {

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -19,7 +19,7 @@ interface IConferenceActionsResponse {
   data: ICallLeg;
 }
 
-export const get = async (
+export const getCall = async (
   params: Partial<ICallLeg & IFindManyParams>
 ): Promise<AxiosResponse<{ calls: ICallLeg[] }>> => {
   return await axios.get(`${BASE_URL}/calls/`, {


### PR DESCRIPTION
Follows https://github.com/team-telnyx/telnyx-client-examples/pull/51

Retrieves call information from the backend using the Telnyx call control ID, fixes issue where incoming call UI flashes before auto-answer.

## ✋ Manual testing

1. Run call-center app and log in
2. Call an external destination. Verify that you see the correct destination in the active call UI, and that you are connected to the conference

NOTE: Incoming call state seems to be broken right now, [see Slack](https://telnyx.slack.com/archives/CM56WJFUM/p1603307929069500)

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots

<img width="621" alt="Screen Shot 2020-10-21 at 1 00 48 PM" src="https://user-images.githubusercontent.com/4672952/96776182-89587100-139d-11eb-837d-f767c6e932f1.png">
