### PR TITLE
Use Call Control ID to identify invite & transfer

### DIFF
--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -113,25 +113,17 @@ class CallsController {
 
   // Invite an agent or phone number to join another agent's conference call
   public static invite = async function (req: Request, res: Response) {
-    let { initiatorSipUsername, to } = req.body;
+    let { to, telnyxCallControlId } = req.body;
 
     try {
-      // Find the correct call leg and conference by inviter's SIP username
-      // TODO Once INIT-1896 is done, the WebRTC SDK will expose the Call Control
-      // ID. We will be able to ask for the conference related to the Call
-      // Control ID directly instead of infering from its participant SIP address
       let callLegRepository = getManager().getRepository(CallLeg);
       let appInviterCallLeg = await callLegRepository.findOneOrFail({
         where: {
-          status: CallLegStatus.ACTIVE,
-          to: `sip:${initiatorSipUsername}@sip.telnyx.com`,
+          telnyxCallControlId,
         },
         relations: ['conference'],
       });
 
-      // NOTE Specifying the host SIP username doesn't seem to work,
-      // possibly because connection ID relationship?
-      // let from = `sip:${initiatorSipUsername}@sip.telnyx.com`;
       let from = process.env.TELNYX_SIP_OB_NUMBER!;
 
       // Call someone to invite them to join the conference call
@@ -164,25 +156,17 @@ class CallsController {
 
   // Transfer the call to an agent or phone number to join
   public static transfer = async function (req: Request, res: Response) {
-    let { initiatorSipUsername, to } = req.body;
+    let { to, telnyxCallControlId } = req.body;
 
     try {
-      // Find the correct call leg and conference by transferer's SIP username
-      // TODO Once INIT-1896 is done, the WebRTC SDK will expose the Call Control
-      // ID. We will be able to ask for the conference related to the Call
-      // Control ID directly instead of infering from its participant SIP address
       let callLegRepository = getManager().getRepository(CallLeg);
       let appTransfererCallLeg = await callLegRepository.findOneOrFail({
         where: {
-          status: CallLegStatus.ACTIVE,
-          to: `sip:${initiatorSipUsername}@sip.telnyx.com`,
+          telnyxCallControlId,
         },
         relations: ['conference'],
       });
 
-      // NOTE Specifying the host SIP username doesn't seem to work,
-      // possibly because connection ID relationship?
-      // let from = `sip:${initiatorSipUsername}@sip.telnyx.com`;
       let from = process.env.TELNYX_SIP_OB_NUMBER!;
 
       // Call someone to invite them to join the conference call

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -65,18 +65,6 @@ class CallsController {
     }
   };
 
-  public static bridge = async function (req: Request, res: Response) {
-    let { call_control_id, to } = req.body.data;
-    let callToBridge = await telnyx.calls.create({
-      connection_id: process.env.TELNYX_SIP_CONNECTION_ID,
-      from: process.env.TELNYX_SIP_OB_NUMBER,
-      to,
-    });
-
-    callToBridge.bridge({ call_control_id });
-    res.json({});
-  };
-
   // Initiate an outgoing call
   public static dial = async function (req: Request, res: Response) {
     let { initiatorSipUsername, to } = req.body;

--- a/call-center/server/routes/calls.ts
+++ b/call-center/server/routes/calls.ts
@@ -6,7 +6,6 @@ let router = express.Router();
 router.get('/', CallsController.get);
 
 // Actions
-router.post('/actions/bridge', CallsController.bridge);
 router.post('/actions/dial', CallsController.dial);
 router.post('/actions/conferences/invite', CallsController.invite);
 router.post('/actions/conferences/transfer', CallsController.transfer);

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -15,6 +15,7 @@ import IConference from '../interfaces/IConference';
 import { CallLegDirection, CallLegStatus } from '../interfaces/ICallLeg';
 
 interface IActiveCall {
+  telnyxCallControlId: string;
   sipUsername: string;
   callDirection: string;
   callDestination: string;
@@ -30,6 +31,7 @@ interface IActiveCall {
 }
 
 interface IActiveCallConference {
+  telnyxCallControlId: string;
   sipUsername: string;
   isIncoming: boolean;
   callDestination: string;
@@ -94,6 +96,7 @@ function MuteUnmuteButton({ isMuted, mute, unmute }: IMuteUnmuteButton) {
 }
 
 function ActiveCallConference({
+  telnyxCallControlId,
   sipUsername,
   callDestination,
   isIncoming,
@@ -115,13 +118,13 @@ function ActiveCallConference({
 
   const addToCall = (destination: string) =>
     invite({
-      initiatorSipUsername: sipUsername,
+      telnyxCallControlId,
       to: destination,
     });
 
   const transferCall = (destination: string) =>
     transfer({
-      initiatorSipUsername: sipUsername,
+      telnyxCallControlId,
       to: destination,
     });
 
@@ -282,6 +285,7 @@ function ActiveCallConference({
 }
 
 function ActiveCall({
+  telnyxCallControlId,
   sipUsername,
   callDirection,
   callDestination,
@@ -343,6 +347,7 @@ function ActiveCall({
         <div className="App-section">
           <div>Call in progress</div>
           <ActiveCallConference
+            telnyxCallControlId={telnyxCallControlId}
             sipUsername={sipUsername}
             isIncoming={isIncoming}
             callDestination={callDestination}

--- a/call-center/web-client/src/components/Common/index.tsx
+++ b/call-center/web-client/src/components/Common/index.tsx
@@ -199,6 +199,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
 
       {webRTCall && (
         <ActiveCall
+          telnyxCallControlId={webRTCall.options.telnyxCallControlId}
           sipUsername={agentSipUsername}
           callDirection={webRTCall.direction}
           callDestination={

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -6,8 +6,11 @@ interface IFindManyParams {
   limit: number;
 }
 
+interface IActiveCallActionParams {
+  telnyxCallControlId: string;
+}
+
 interface ICallActionsParams {
-  initiatorSipUsername: string;
   to: string;
 }
 
@@ -44,7 +47,7 @@ export const dial = async (
 };
 
 export const invite = async (
-  params: ICallActionsParams
+  params: ICallActionsParams & IActiveCallActionParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/invite`, params, {
@@ -57,7 +60,7 @@ export const invite = async (
 };
 
 export const transfer = async (
-  params: ICallActionsParams
+  params: ICallActionsParams & IActiveCallActionParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/transfer`, params, {


### PR DESCRIPTION
Uses Telnyx CC ID to identify a call when inviting someone to a conference or transferring a call.

## ✋ Manual testing

Note: Run `npm install` to make sure you have the latest @telnyx/webrtc version (2.2.0)

1. Run call-center app and log in as multiple agents
2. Call your call center app and answer
3. Transfer the call to an agent. Verify that agent receives and can answer call
4. Add the other agent to the conference call. Verify that the other agent receives & can answer
6. Hang up and repeat for with an outbound call

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [x] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots