### PR TITLE
Use Call Control ID in conference actions

### DIFF
--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -197,14 +197,13 @@ class CallsController {
   // Mute a call
   // NOTE call must be active participant in a conference
   public static mute = async function (req: Request, res: Response) {
-    let { participant } = req.body;
+    let { telnyxCallControlId } = req.body;
 
     try {
       let callLegRepository = getManager().getRepository(CallLeg);
       let appCall = await callLegRepository.findOneOrFail({
         where: {
-          status: CallLegStatus.ACTIVE,
-          to: participant,
+          telnyxCallControlId,
         },
         relations: ['conference'],
       });
@@ -239,14 +238,13 @@ class CallsController {
   // Unmute a call
   // NOTE call must be active participant in a conference
   public static unmute = async function (req: Request, res: Response) {
-    let { participant } = req.body;
+    let { telnyxCallControlId } = req.body;
 
     try {
       let callLegRepository = getManager().getRepository(CallLeg);
       let appCall = await callLegRepository.findOneOrFail({
         where: {
-          status: CallLegStatus.ACTIVE,
-          to: participant,
+          telnyxCallControlId,
         },
         relations: ['conference'],
       });
@@ -281,14 +279,13 @@ class CallsController {
   // Hang up a call by the specified destination, e.g. to remove a number
   // from a conference call
   public static hangup = async function (req: Request, res: Response) {
-    let { participant } = req.body;
+    let { telnyxCallControlId } = req.body;
 
     try {
       let callLegRepository = getManager().getRepository(CallLeg);
       let appCall = await callLegRepository.findOneOrFail({
         where: {
-          status: CallLegStatus.ACTIVE,
-          to: participant,
+          telnyxCallControlId,
         },
       });
 

--- a/call-center/server/controllers/conferences.controller.ts
+++ b/call-center/server/controllers/conferences.controller.ts
@@ -13,13 +13,16 @@ class ConferencesController {
 
       let appConference = await conferenceRepository
         .createQueryBuilder('conference')
-        .innerJoinAndSelect(
+        .innerJoin(
           'conference.callLegs',
           'callLeg',
           'callLeg.telnyxCallControlId = :telnyxCallControlId',
           { telnyxCallControlId }
         )
+        .leftJoinAndSelect('conference.callLegs', 'callLegs')
         .getOne();
+
+      console.log('appConference:', appConference);
 
       res.json({
         conference: appConference,

--- a/call-center/server/controllers/conferences.controller.ts
+++ b/call-center/server/controllers/conferences.controller.ts
@@ -13,16 +13,16 @@ class ConferencesController {
 
       let appConference = await conferenceRepository
         .createQueryBuilder('conference')
+        // Find conference by call leg with matching CC ID
         .innerJoin(
           'conference.callLegs',
           'callLeg',
           'callLeg.telnyxCallControlId = :telnyxCallControlId',
           { telnyxCallControlId }
         )
+        // Return all call legs with the conference
         .leftJoinAndSelect('conference.callLegs', 'callLegs')
         .getOne();
-
-      console.log('appConference:', appConference);
 
       res.json({
         conference: appConference,

--- a/call-center/server/controllers/conferences.controller.ts
+++ b/call-center/server/controllers/conferences.controller.ts
@@ -1,17 +1,25 @@
 import { Conference } from '../entities/conference.entity';
 import { Request, Response } from 'express';
-import { getManager } from 'typeorm';
+import { getManager, createQueryBuilder } from 'typeorm';
 import { CallLeg, CallLegStatus } from '../entities/callLeg.entity';
 
 class ConferencesController {
+  // Find conference by call leg Call Control ID
   public static get = async function (req: Request, res: Response) {
-    let idOrSipAddress = req.params.id_or_sip_address;
+    let telnyxCallControlId = req.params.telnyx_call_control_id;
 
     try {
-      let isSipAddress = idOrSipAddress.startsWith('sip:');
-      let appConference = isSipAddress
-        ? await ConferencesController.getConferenceBySipAddress(idOrSipAddress)
-        : await ConferencesController.getConferenceByID(idOrSipAddress);
+      let conferenceRepository = getManager().getRepository(Conference);
+
+      let appConference = await conferenceRepository
+        .createQueryBuilder('conference')
+        .innerJoinAndSelect(
+          'conference.callLegs',
+          'callLeg',
+          'callLeg.telnyxCallControlId = :telnyxCallControlId',
+          { telnyxCallControlId }
+        )
+        .getOne();
 
       res.json({
         conference: appConference,
@@ -23,39 +31,6 @@ class ConferencesController {
         .status(e && e.name === 'EntityNotFound' ? 404 : 500)
         .send({ error: e });
     }
-  };
-
-  private static getConferenceBySipAddress = async function (
-    sipAddress: string
-  ) {
-    // TODO Once INIT-1896 is done, the WebRTC SDK will expose the Call Control
-    // ID. We will be able to ask for the conference related to the Call
-    // Control ID directly instead of infering from its participant SIP address
-    let callLegRepository = getManager().getRepository(CallLeg);
-    let appTransfererCallLeg = await callLegRepository.findOneOrFail({
-      where: {
-        status: CallLegStatus.ACTIVE,
-        to: sipAddress,
-      },
-      relations: ['conference', 'conference.callLegs'],
-    });
-
-    return appTransfererCallLeg.conference;
-  };
-
-  private static getConferenceByID = async function (id: string) {
-    // TODO Once INIT-1896 is done, the WebRTC SDK will expose the Call Control
-    // ID. We will be able to ask for the conference related to the Call
-    // Control ID directly instead of infering from its participant SIP address
-    let conferenceRepository = getManager().getRepository(Conference);
-    let appConference = await conferenceRepository.findOneOrFail({
-      where: {
-        id,
-      },
-      relations: ['callLegs'],
-    });
-
-    return appConference;
   };
 }
 

--- a/call-center/server/routes/conferences.ts
+++ b/call-center/server/routes/conferences.ts
@@ -4,6 +4,6 @@ import ConferencesController from '../controllers/conferences.controller';
 let router = express.Router();
 
 // Actions
-router.get('/:id_or_sip_address', ConferencesController.get);
+router.get('/:telnyx_call_control_id', ConferencesController.get);
 
 export default router;

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -52,7 +52,7 @@ interface IMuteUnmuteButton {
   unmute: () => void;
 }
 
-function useActiveConference(sipUsername: string) {
+function useActiveConference(telnyxCallControlId: string) {
   let [loading, setLoading] = useState<boolean>(true);
   let [error, setError] = useState<string | undefined>();
   let [conference, setConference] = useState<IConference | undefined>();
@@ -60,7 +60,7 @@ function useActiveConference(sipUsername: string) {
   function loadConference() {
     setLoading(true);
 
-    return getConference(`sip:${sipUsername}@sip.telnyx.com`)
+    return getConference(telnyxCallControlId)
       .then((res) => {
         setConference(res.data.conference);
       })
@@ -108,7 +108,7 @@ function ActiveCallConference({
     loading: conferenceLoading,
     error: conferenceError,
     conference,
-  } = useActiveConference(sipUsername);
+  } = useActiveConference(telnyxCallControlId);
   let [newParticipant, setNewParticipant] = useState('');
 
   const handleChangeDestination = (

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -223,11 +223,11 @@ function ActiveCallConference({
     <div className="ActiveCall-conference">
       <div>
         {conferenceParticipants.map(
-          (
-            { muted, displayName, participant, participantTelnyxCallControlId },
-            index
-          ) => (
-            <div className="ActiveCall-participant-row">
+          ({ muted, displayName, participantTelnyxCallControlId }, index) => (
+            <div
+              className="ActiveCall-participant-row"
+              key={participantTelnyxCallControlId}
+            >
               <div className="ActiveCall-participant">
                 {index !== 0 ? (
                   <span className="ActiveCall-ampersand">&</span>

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -129,14 +129,14 @@ function ActiveCallConference({
     });
 
   const removeParticipant = (participant: string) => {
-    appHangup({ participant });
+    appHangup({ telnyxCallControlId, participant });
   };
 
   const muteParticipant = (participant: string) => {
-    appMute({ participant });
+    appMute({ telnyxCallControlId, participant });
   };
   const unmuteParticipant = (participant: string) => {
-    appUnmute({ participant });
+    appUnmute({ telnyxCallControlId, participant });
   };
 
   const confirmRemove = (participant: string) => {

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -160,7 +160,7 @@ function ActiveCallConference({
   };
 
   let conferenceParticipants: IConferenceParticipant[] = useMemo(() => {
-    if (conference) {
+    if (conference?.callLegs?.length) {
       let otherParticipants = conference.callLegs
         .filter((callLeg) => callLeg.status === CallLegStatus.ACTIVE)
         .map((callLeg) => ({

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -14,7 +14,7 @@ interface ICallActionsParams {
   to: string;
 }
 
-interface IConferenceActionsParams {
+interface IConferenceActionsParams extends IActiveCallActionParams {
   participant: string;
 }
 

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -14,10 +14,6 @@ interface ICallActionsParams {
   to: string;
 }
 
-interface IConferenceActionsParams extends IActiveCallActionParams {
-  participant: string;
-}
-
 interface IConferenceActionsResponse {
   data: ICallLeg;
 }
@@ -73,7 +69,7 @@ export const transfer = async (
 };
 
 export const hangup = async (
-  params: IConferenceActionsParams
+  params: IActiveCallActionParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/hangup`, params, {
@@ -86,7 +82,7 @@ export const hangup = async (
 };
 
 export const mute = async (
-  params: IConferenceActionsParams
+  params: IActiveCallActionParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/mute`, params, {
@@ -99,7 +95,7 @@ export const mute = async (
 };
 
 export const unmute = async (
-  params: IConferenceActionsParams
+  params: IActiveCallActionParams
 ): Promise<AxiosResponse | AxiosError> => {
   return await axios
     .post(`${BASE_URL}/calls/actions/conferences/unmute`, params, {

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -18,7 +18,7 @@ interface IConferenceActionsResponse {
   data: ICallLeg;
 }
 
-export const get = async (
+export const getCall = async (
   params: Partial<ICallLeg & IFindManyParams>
 ): Promise<AxiosResponse<{ calls: ICallLeg[] }>> => {
   return await axios.get(`${BASE_URL}/calls/`, {

--- a/call-center/web-client/src/services/conferencesService.ts
+++ b/call-center/web-client/src/services/conferencesService.ts
@@ -3,9 +3,9 @@ import IConference from '../interfaces/IConference';
 import { BASE_URL } from '../configs/constants';
 
 export const getConference = async (
-  id: string
+  telnyxCallControlId: string
 ): Promise<AxiosResponse<{ conference: IConference }>> => {
-  return await axios.get(`${BASE_URL}/conferences/${id}`, {
+  return await axios.get(`${BASE_URL}/conferences/${telnyxCallControlId}`, {
     headers: {
       'Content-Type': 'application/json',
     },


### PR DESCRIPTION
Uses Telnyx CC ID to get a conference & identify a call when muting, unmuting and removing someone from a conference call.

## ✋ Manual testing

Note: Run `npm install` to make sure you have the latest @telnyx/webrtc version (2.2.0)

1. Run call-center app and log in as multiple agents
2. Call your call center app and answer
3. Add another agent to the call and answer. Verify that mute, unmute and remove from call works


## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [x] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots