### PR TITLE
Mute & unmute self with Call Control

### DIFF
--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -9,10 +9,16 @@ import {
   hangup as appHangup,
   mute as appMute,
   unmute as appUnmute,
+  getCall as appGetCall,
 } from '../services/callsService';
 import { getConference } from '../services/conferencesService';
 import IConference from '../interfaces/IConference';
-import { CallLegDirection, CallLegStatus } from '../interfaces/ICallLeg';
+import {
+  ICallLeg,
+  CallLegDirection,
+  CallLegStatus,
+  CallLegClientCallState,
+} from '../interfaces/ICallLeg';
 
 interface IActiveCall {
   telnyxCallControlId: string;
@@ -48,6 +54,41 @@ interface IMuteUnmuteButton {
   isMuted?: boolean;
   mute: () => void;
   unmute: () => void;
+}
+
+function getCall(telnyxCallControlId: string) {
+  return appGetCall({
+    telnyxCallControlId: telnyxCallControlId,
+    limit: 1,
+  }).then((res) => res.data?.calls?.[0]);
+}
+
+function useAppCall(telnyxCallControlId: string) {
+  let [loading, setLoading] = useState<boolean>(true);
+  let [error, setError] = useState<string | undefined>();
+  let [call, setCall] = useState<ICallLeg | undefined>();
+
+  function loadCall() {
+    setLoading(true);
+
+    return getCall(telnyxCallControlId)
+      .then((appCall) => {
+        if (appCall) {
+          setCall(appCall);
+        } else {
+          throw new Error('Call by Telnyx Call Control ID not found in DB');
+        }
+      })
+      .catch((error) => {
+        setError(error.toString());
+      })
+      .finally(() => setLoading(false));
+  }
+
+  // Poll for Call state every second
+  useInterval(loadCall, 1000);
+
+  return { loading, error, call };
 }
 
 function useActiveConference(telnyxCallControlId: string) {
@@ -301,23 +342,37 @@ function ActiveCall({
   answer,
   hangup,
 }: IActiveCall) {
-  const [isMuted, setIsMuted] = useState(false);
+  const { call } = useAppCall(telnyxCallControlId);
 
   const handleAnswerClick = () => answer();
   const handleRejectClick = () => hangup();
   const handleHangupClick = () => hangup();
 
   const muteSelf = () => {
-    setIsMuted(true);
     appMute({ telnyxCallControlId });
   };
 
   const unmuteSelf = () => {
     appUnmute({ telnyxCallControlId });
-    setIsMuted(false);
   };
 
-  const isIncoming = callDirection === 'inbound';
+  // Run effects on state change
+  useEffect(() => {
+    // Get server app call state
+    getCall(telnyxCallControlId).then((appCall) => {
+      if (callState === 'new') {
+        // Check if call should be answered automatically, such as in
+        // the case when the agent has initiated an outgoing call:
+        // when an agent dials a number, the call is routed through
+        // the call center app, a conference is created, and both the
+        // agent and external number is invited to the conference.
+        if (appCall.clientCallState === CallLegClientCallState.AUTO_ANSWER) {
+          answer();
+        }
+      }
+    });
+  }, [callState]);
+
   const isRinging = callState === 'ringing';
   const isActive = callState === 'active';
 
@@ -366,11 +421,13 @@ function ActiveCall({
               Hangup
             </button>
 
-            <MuteUnmuteButton
-              isMuted={isMuted}
-              mute={muteSelf}
-              unmute={unmuteSelf}
-            />
+            {call && (
+              <MuteUnmuteButton
+                isMuted={call.muted}
+                mute={muteSelf}
+                unmute={unmuteSelf}
+              />
+            )}
           </div>
         </div>
       )}

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -26,8 +26,6 @@ interface IActiveCall {
   isDialing: boolean;
   answer: Function;
   hangup: Function;
-  muteAudio: Function;
-  unmuteAudio: Function;
 }
 
 interface IActiveCallConference {
@@ -302,8 +300,6 @@ function ActiveCall({
   isDialing,
   answer,
   hangup,
-  muteAudio,
-  unmuteAudio,
 }: IActiveCall) {
   const [isMuted, setIsMuted] = useState(false);
 
@@ -313,11 +309,11 @@ function ActiveCall({
 
   const muteSelf = () => {
     setIsMuted(true);
-    muteAudio();
+    appMute({ telnyxCallControlId });
   };
 
   const unmuteSelf = () => {
-    unmuteAudio();
+    appUnmute({ telnyxCallControlId });
     setIsMuted(false);
   };
 

--- a/call-center/web-client/src/components/Common/index.tsx
+++ b/call-center/web-client/src/components/Common/index.tsx
@@ -3,7 +3,6 @@ import { TelnyxRTC } from '@telnyx/webrtc';
 import { IWebRTCCall } from '@telnyx/webrtc/lib/Modules/Verto/webrtc/interfaces';
 import { updateAgent, getLoggedInAgents } from '../../services/agentsService';
 import * as callsService from '../../services/callsService';
-import { CallLegClientCallState } from '../../interfaces/ICallLeg';
 import useAgents from '../../hooks/useAgents';
 import ActiveCall from '../ActiveCall';
 import Agents from '../Agents';
@@ -139,38 +138,6 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
       telnyxClientRef.current = undefined;
     };
   }, [token, agentId]);
-
-  // Run effects on state change
-  useEffect(() => {
-    if (!webRTCall?.state) {
-      return;
-    }
-
-    const { state, options, answer } = webRTCall;
-
-    // Check server app call state
-    callsService
-      .get({
-        telnyxCallControlId: options.telnyxCallControlId,
-        limit: 1,
-      })
-      .then(({ data }) => {
-        // Check if call should be answered automatically, such as in
-        // the case when the agent has initiated an outgoing call:
-        // when an agent dials a number, the call is routed through
-        // the call center app, a conference is created, and both the
-        // agent and external number is invited to the conference.
-        if (state === 'new') {
-          if (
-            data.calls[0]?.clientCallState ===
-              CallLegClientCallState.AUTO_ANSWER &&
-            isMountedRef.current
-          ) {
-            answer();
-          }
-        }
-      });
-  }, [webRTCall?.state]);
 
   const dial = useCallback(
     (destination) => {

--- a/call-center/web-client/src/components/Common/index.tsx
+++ b/call-center/web-client/src/components/Common/index.tsx
@@ -109,7 +109,13 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
 
           updateAgent(agentId, { available: true });
         } else {
-          let nextWebRTCall = {
+          if (state === 'answering') {
+            updateAgent(agentId, { available: false });
+          } else if (state === 'active') {
+            setDialingDestination(null);
+          }
+
+          setWebRTCCall({
             state,
             direction,
             options,
@@ -118,35 +124,7 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
             hangup: hangup.bind(notification.call),
             muteAudio: muteAudio.bind(notification.call),
             unmuteAudio: unmuteAudio.bind(notification.call),
-          };
-
-          if (state === 'answering') {
-            updateAgent(agentId, { available: false });
-          } else if (state === 'new') {
-            // Check if call should be answered automatically, such as in
-            // the case when the agent has initiated an outgoing call:
-            // when an agent dials a number, the call is routed through
-            // the call center app, a conference is created, and both the
-            // agent and external number is invited to the conference.
-            callsService
-              .get({
-                telnyxCallControlId: options.telnyxCallControlId,
-                limit: 1,
-              })
-              .then(({ data }) => {
-                if (
-                  data.calls[0]?.clientCallState ===
-                    CallLegClientCallState.AUTO_ANSWER &&
-                  isMountedRef.current
-                ) {
-                  nextWebRTCall.answer();
-                }
-              });
-          } else if (state === 'active') {
-            setDialingDestination(null);
-          }
-
-          setWebRTCCall(nextWebRTCall);
+          });
         }
       }
     });
@@ -161,6 +139,38 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
       telnyxClientRef.current = undefined;
     };
   }, [token, agentId]);
+
+  // Run effects on state change
+  useEffect(() => {
+    if (!webRTCall?.state) {
+      return;
+    }
+
+    const { state, options, answer } = webRTCall;
+
+    // Check server app call state
+    callsService
+      .get({
+        telnyxCallControlId: options.telnyxCallControlId,
+        limit: 1,
+      })
+      .then(({ data }) => {
+        // Check if call should be answered automatically, such as in
+        // the case when the agent has initiated an outgoing call:
+        // when an agent dials a number, the call is routed through
+        // the call center app, a conference is created, and both the
+        // agent and external number is invited to the conference.
+        if (state === 'new') {
+          if (
+            data.calls[0]?.clientCallState ===
+              CallLegClientCallState.AUTO_ANSWER &&
+            isMountedRef.current
+          ) {
+            answer();
+          }
+        }
+      });
+  }, [webRTCall?.state]);
 
   const dial = useCallback(
     (destination) => {
@@ -213,8 +223,6 @@ function Common({ agentId, agentSipUsername, agentName, token }: ICommon) {
           callState={webRTCall.state}
           answer={webRTCall.answer}
           hangup={webRTCall.hangup}
-          muteAudio={webRTCall.muteAudio}
-          unmuteAudio={webRTCall.unmuteAudio}
         />
       )}
 

--- a/call-center/web-client/src/services/callsService.ts
+++ b/call-center/web-client/src/services/callsService.ts
@@ -18,7 +18,7 @@ interface IConferenceActionsResponse {
   data: ICallLeg;
 }
 
-export const get = async (
+export const getCall = async (
   params: Partial<ICallLeg & IFindManyParams>
 ): Promise<AxiosResponse<{ calls: ICallLeg[] }>> => {
   return await axios.get(`${BASE_URL}/calls/`, {


### PR DESCRIPTION
Mute & unmute self with Call Control, and gets muted state from the server.

## ✋ Manual testing

Note: Run `npm install` to make sure you have the latest @telnyx/webrtc version (2.2.0)

1. Run call-center app and log in as multiple agents
2. Call your call center app and answer
3. Add another agent to the call and answer
4. Mute and unmute one of the agents. Verify that agent mute state is represented in all views
5. Mute and unmute self Verify that self mute state is represented in all views


## 🦊 Browser testing

### Desktop
- [ ] Edge
- [ ] Chrome
- [x] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots