### PR TITLE
Improve call control flow

### DIFF
--- a/call-center/server/controllers/conferences.controller.ts
+++ b/call-center/server/controllers/conferences.controller.ts
@@ -1,7 +1,6 @@
 import { Conference } from '../entities/conference.entity';
 import { Request, Response } from 'express';
 import { getManager, createQueryBuilder } from 'typeorm';
-import { CallLeg, CallLegStatus } from '../entities/callLeg.entity';
 
 class ConferencesController {
   // Find conference by call leg Call Control ID
@@ -22,6 +21,9 @@ class ConferencesController {
         )
         // Return all call legs with the conference
         .leftJoinAndSelect('conference.callLegs', 'callLegs')
+        .orderBy({
+          'callLegs.createdAt': 'ASC',
+        })
         .getOne();
 
       res.json({

--- a/call-center/server/entities/callLeg.entity.ts
+++ b/call-center/server/entities/callLeg.entity.ts
@@ -9,6 +9,7 @@ import { Conference } from './conference.entity';
 
 export enum CallLegStatus {
   INACTIVE = 'inactive',
+  NEW = 'new',
   ACTIVE = 'active',
 }
 
@@ -33,7 +34,7 @@ export class CallLeg {
   @Column({
     type: 'simple-enum',
     enum: CallLegStatus,
-    default: CallLegStatus.INACTIVE,
+    default: CallLegStatus.NEW,
   })
   status!: string;
 

--- a/call-center/server/entities/callLeg.entity.ts
+++ b/call-center/server/entities/callLeg.entity.ts
@@ -1,4 +1,10 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+} from 'typeorm';
 import { Conference } from './conference.entity';
 
 export enum CallLegStatus {
@@ -20,6 +26,9 @@ export enum CallLegDirection {
 export class CallLeg {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
 
   @Column({
     type: 'simple-enum',

--- a/call-center/web-client/src/components/ActiveCall.css
+++ b/call-center/web-client/src/components/ActiveCall.css
@@ -46,6 +46,10 @@
   font-weight: bold;
 }
 
+.ActiveCall-participant--inactive {
+  opacity: 0.5;
+}
+
 .ActiveCall-ampersand {
   display: inline-block;
   margin-right: 1rem;

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -37,8 +37,6 @@ interface IActiveCall {
 interface IActiveCallConference {
   telnyxCallControlId: string;
   sipUsername: string;
-  isDialing: boolean;
-  callDestination: string;
   callerId: string;
   agents?: IAgent[];
 }
@@ -139,9 +137,6 @@ function MuteUnmuteButton({ isMuted, mute, unmute }: IMuteUnmuteButton) {
 function ActiveCallConference({
   telnyxCallControlId,
   sipUsername,
-  callDestination,
-  isDialing,
-  callerId,
 }: IActiveCallConference) {
   let { agents } = useAgents(sipUsername);
   let {
@@ -210,8 +205,7 @@ function ActiveCallConference({
               : callLeg.to,
         }))
         .filter(
-          ({ participant }) =>
-            participant !== `sip:${sipUsername}@sip.telnyx.com`
+          (callLeg) => telnyxCallControlId !== callLeg.telnyxCallControlId
         )
         .map(({ muted, participant, telnyxCallControlId, status }) => {
           let conferenceParticipant = {
@@ -235,19 +229,10 @@ function ActiveCallConference({
         });
 
       return otherParticipants;
-    } else if (isDialing) {
-      return [
-        {
-          status: CallLegStatus.NEW,
-          displayName: callDestination,
-          participantTelnyxCallControlId: telnyxCallControlId,
-          participant: callDestination,
-        },
-      ];
     }
 
     return [];
-  }, [conference, isDialing, telnyxCallControlId, callDestination]);
+  }, [conference, telnyxCallControlId]);
 
   useEffect(() => {
     if (
@@ -417,14 +402,18 @@ function ActiveCall({
           </div>
         </div>
       )}
-      {(isDialing || isActive) && (
+      {isDialing && !isActive && (
+        <div className="App-section">
+          <div>Calling...</div>
+          <div className="ActiveCall-callerId">{callDestination}</div>
+        </div>
+      )}
+      {!isDialing && isActive && (
         <div className="App-section">
           <div>Call in progress</div>
           <ActiveCallConference
             telnyxCallControlId={telnyxCallControlId}
             sipUsername={sipUsername}
-            isDialing={isDialing}
-            callDestination={callDestination}
             callerId={callerId}
           />
           <div className="ActiveCall-actions">

--- a/call-center/web-client/src/components/ActiveCall.tsx
+++ b/call-center/web-client/src/components/ActiveCall.tsx
@@ -44,7 +44,7 @@ interface IActiveCallConference {
 }
 
 interface IConferenceParticipant {
-  isActive: boolean;
+  status: CallLegStatus;
   displayName: string;
   muted?: boolean;
   participantTelnyxCallControlId: string;
@@ -215,7 +215,7 @@ function ActiveCallConference({
         )
         .map(({ muted, participant, telnyxCallControlId, status }) => {
           let conferenceParticipant = {
-            isActive: status === CallLegStatus.ACTIVE,
+            status,
             displayName: participant,
             muted,
             participant,
@@ -238,7 +238,7 @@ function ActiveCallConference({
     } else if (isDialing) {
       return [
         {
-          isActive: true,
+          status: CallLegStatus.NEW,
           displayName: callDestination,
           participantTelnyxCallControlId: telnyxCallControlId,
           participant: callDestination,
@@ -265,7 +265,7 @@ function ActiveCallConference({
       <div>
         {conferenceParticipants.map(
           (
-            { isActive, muted, displayName, participantTelnyxCallControlId },
+            { status, muted, displayName, participantTelnyxCallControlId },
             index
           ) => (
             <div
@@ -273,8 +273,10 @@ function ActiveCallConference({
               key={participantTelnyxCallControlId}
             >
               <div
-                className={`ActiveCall-participant ${
-                  isActive ? '' : 'ActiveCall-participant--inactive'
+                className={`ActiveCall-participant${
+                  status === CallLegStatus.INACTIVE
+                    ? ' ActiveCall-participant--inactive'
+                    : ''
                 }`}
               >
                 {index !== 0 ? (
@@ -284,8 +286,8 @@ function ActiveCallConference({
                   {displayName}
                 </span>
               </div>
-              {isActive && (
-                <div className="ActiveCall-actions">
+              <div className="ActiveCall-actions">
+                {status === CallLegStatus.ACTIVE && (
                   <MuteUnmuteButton
                     isMuted={muted}
                     mute={() => muteParticipant(participantTelnyxCallControlId)}
@@ -293,7 +295,9 @@ function ActiveCallConference({
                       unmuteParticipant(participantTelnyxCallControlId)
                     }
                   />
+                )}
 
+                {status !== CallLegStatus.INACTIVE && (
                   <button
                     type="button"
                     className="App-button App-button--small App-button--danger"
@@ -303,8 +307,8 @@ function ActiveCallConference({
                   >
                     Remove
                   </button>
-                </div>
-              )}
+                )}
+              </div>
             </div>
           )
         )}
@@ -377,7 +381,7 @@ function ActiveCall({
         // when an agent dials a number, the call is routed through
         // the call center app, a conference is created, and both the
         // agent and external number is invited to the conference.
-        if (appCall.clientCallState === CallLegClientCallState.AUTO_ANSWER) {
+        if (appCall?.clientCallState === CallLegClientCallState.AUTO_ANSWER) {
           answer();
         }
       }

--- a/call-center/web-client/src/interfaces/ICallLeg.ts
+++ b/call-center/web-client/src/interfaces/ICallLeg.ts
@@ -3,6 +3,7 @@ import IConference from './IConference';
 // TODO Same import as in `callLeg.entity`
 export enum CallLegStatus {
   INACTIVE = 'inactive',
+  NEW = 'new',
   ACTIVE = 'active',
 }
 

--- a/call-center/web-client/src/interfaces/IConference.ts
+++ b/call-center/web-client/src/interfaces/IConference.ts
@@ -4,6 +4,7 @@ export interface IConference {
   id: string;
   telnyxConferenceId: string;
   from: string;
+  to: string;
   callLegs: ICallLeg[];
 }
 


### PR DESCRIPTION
Proposed changes to improve dial call control flow and UI representation. Main changes:
- Create all call legs and conference in the `CallsController.dial` method so that a conference exists before the agent answers
- Reduce call control answered switch cases by combining `dial` and `initiate_dial` into `join_conference`
- Add an additional new status to the call leg, so that the active call UI differentiates between initiated calls and answered calls
- Show separate UI for dialing, instead of trying to mimic the shape of an active call

## ✋ Manual testing

Run call center app and make an outbound call. App should function as expected

## 🦊 Browser testing

### Desktop
- [ ] Edge
- [x] Chrome
- [x] Firefox
- [ ] Safari

### Mobile
- [ ] Chrome (Android)
- [ ] Safari (iOS)

## 📸 Screenshots