### PR TITLE
Update call center server tests

### DIFF
--- a/call-center/server/controllers/calls.controller.test.ts
+++ b/call-center/server/controllers/calls.controller.test.ts
@@ -1,0 +1,418 @@
+import { getRepository } from 'typeorm';
+import { CallLeg, CallLegClientCallState } from '../entities/callLeg.entity';
+import { Conference } from '../entities/conference.entity';
+import TestFactory from '../TestFactory';
+import CallsController, { encodeClientState } from './calls.controller';
+
+const telnyxMock = require('telnyx');
+
+const testFactory = new TestFactory();
+const mockRes = { json: () => {} };
+
+beforeAll(async () => {
+  await testFactory.init();
+});
+
+beforeEach(async () => {
+  await testFactory.clear();
+  await testFactory.loadFixtures();
+  telnyxMock.mockClear();
+});
+
+afterAll(async () => {
+  await testFactory.close();
+});
+
+describe('.dial', () => {
+  test('creates and answers inbound app call leg', async () => {
+    telnyxMock.callMock.answer.mockClear();
+
+    const req = {
+      body: {
+        to: '+15551231234',
+        initiatorSipUsername: 'agent1SipUsername',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.dial(req, mockRes);
+
+    const call = await getRepository(CallLeg).findOne({
+      where: {
+        to: process.env.TELNYX_SIP_OB_NUMBER,
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+      },
+    });
+
+    expect(call).toBeDefined();
+    expect(telnyxMock.callMock.answer).toHaveBeenCalled();
+  });
+
+  test('creates the correct conference call legs', async () => {
+    telnyxMock.callsCreateMock.mockClear();
+    telnyxMock.conferencesCreateMock.mockClear();
+
+    const req = {
+      body: {
+        to: '+15551231234',
+        initiatorSipUsername: 'agent1SipUsername',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.dial(req, mockRes);
+
+    const conference = await getRepository(Conference).findOne({
+      where: {
+        to: '+15551231234',
+        from: 'sip:agent1SipUsername@sip.telnyx.com',
+      },
+      relations: ['callLegs'],
+    });
+
+    expect(conference?.callLegs).toHaveLength(2);
+    expect(conference?.callLegs?.[0]).toEqual(
+      expect.objectContaining({
+        clientCallState: 'auto_answer',
+        direction: 'outgoing',
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        muted: false,
+        status: 'new',
+        telnyxCallControlId: 'fake_call_control_id',
+        telnyxConnectionId: process.env.TELNYX_CC_APP_ID,
+        to: 'sip:agent1SipUsername@sip.telnyx.com',
+      })
+    );
+    expect(conference?.callLegs?.[1]).toEqual(
+      expect.objectContaining({
+        clientCallState: 'default',
+        direction: 'outgoing',
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        muted: false,
+        status: 'new',
+        telnyxCallControlId: 'fake_call_control_id',
+        telnyxConnectionId: process.env.TELNYX_CC_APP_ID,
+        to: '+15551231234',
+      })
+    );
+    expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
+    expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        to: 'sip:agent1SipUsername@sip.telnyx.com',
+      })
+    );
+    expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        to: '+15551231234',
+      })
+    );
+  });
+});
+
+describe('.invite', () => {
+  test('creates the correct conference call legs', async () => {
+    telnyxMock.callsCreateMock.mockClear();
+
+    const req = {
+      body: {
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+        telnyxCallControlId: 'telnyxCallControlId1',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.invite(req, mockRes);
+
+    const conference = await getRepository(Conference).findOne('conference1', {
+      relations: ['callLegs'],
+    });
+
+    expect(conference?.callLegs).toHaveLength(2);
+    expect(conference?.callLegs?.[0]).toEqual(
+      expect.objectContaining({
+        clientCallState: 'default',
+        direction: 'incoming',
+        to: 'sip:agent1SipUsername@sip.telnyx.com',
+      })
+    );
+    expect(conference?.callLegs?.[1]).toEqual(
+      expect.objectContaining({
+        clientCallState: 'default',
+        direction: 'outgoing',
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        muted: false,
+        status: 'new',
+        telnyxCallControlId: 'fake_call_control_id',
+        telnyxConnectionId: 'telnyxConnectionId1',
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      })
+    );
+    expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      })
+    );
+  });
+});
+
+describe('.transfer', () => {
+  test('creates the correct conference call legs', async () => {
+    telnyxMock.callMock.hangup.mockClear();
+    telnyxMock.callsCreateMock.mockClear();
+
+    const req = {
+      body: {
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+        telnyxCallControlId: 'telnyxCallControlId1',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.transfer(req, mockRes);
+
+    const conference = await getRepository(Conference).findOne('conference1', {
+      relations: ['callLegs'],
+    });
+
+    expect(conference?.callLegs).toHaveLength(2);
+    expect(conference?.callLegs?.[0]).toEqual(
+      expect.objectContaining({
+        clientCallState: 'default',
+        direction: 'incoming',
+        to: 'sip:agent1SipUsername@sip.telnyx.com',
+      })
+    );
+    expect(conference?.callLegs?.[1]).toEqual(
+      expect.objectContaining({
+        clientCallState: 'default',
+        direction: 'outgoing',
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        muted: false,
+        status: 'new',
+        telnyxCallControlId: 'fake_call_control_id',
+        telnyxConnectionId: 'telnyxConnectionId1',
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      })
+    );
+    expect(telnyxMock.callMock.hangup).toHaveBeenCalled();
+    expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: process.env.TELNYX_SIP_OB_NUMBER,
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      })
+    );
+  });
+});
+
+describe('.hangup', () => {
+  test('hangs up the Telnxy call', async () => {
+    telnyxMock.callMock.hangup.mockClear();
+
+    const req = {
+      body: {
+        telnyxCallControlId: 'telnyxCallControlId1',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.hangup(req, mockRes);
+
+    expect(telnyxMock.callMock.hangup).toHaveBeenCalled();
+  });
+});
+
+describe('.mute', () => {
+  test('mutes the Telnyx Call', async () => {
+    telnyxMock.conferenceMock.mute.mockClear();
+
+    const req = {
+      body: {
+        telnyxCallControlId: 'telnyxCallControlId1',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.mute(req, mockRes);
+
+    expect(telnyxMock.conferenceMock.mute).toHaveBeenCalledWith({
+      call_control_ids: ['telnyxCallControlId1'],
+    });
+  });
+
+  test('marks the call as muted in DB', async () => {
+    telnyxMock.conferenceMock.mute.mockClear();
+
+    const req = {
+      body: {
+        telnyxCallControlId: 'telnyxCallControlId1',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.mute(req, mockRes);
+
+    let call = await getRepository(CallLeg).findOne({
+      telnyxCallControlId: req.body.telnyxCallControlId,
+    });
+
+    expect(call?.muted).toEqual(true);
+  });
+});
+
+describe('.unmute', () => {
+  test('unmutes the Telnyx Call', async () => {
+    telnyxMock.conferenceMock.unmute.mockClear();
+
+    const req = {
+      body: {
+        telnyxCallControlId: 'telnyxCallControlId2',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.unmute(req, mockRes);
+
+    expect(telnyxMock.conferenceMock.unmute).toHaveBeenCalledWith({
+      call_control_ids: ['telnyxCallControlId2'],
+    });
+  });
+
+  test('marks the call as unmuted in DB', async () => {
+    telnyxMock.conferenceMock.unmute.mockClear();
+
+    const req = {
+      body: {
+        telnyxCallControlId: 'telnyxCallControlId2',
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.unmute(req, mockRes);
+
+    let call = await getRepository(CallLeg).findOne({
+      telnyxCallControlId: req.body.telnyxCallControlId,
+    });
+
+    expect(call?.muted).toEqual(false);
+  });
+});
+
+describe('.callControl', () => {
+  test('handles new incoming calls', async () => {
+    telnyxMock.callMock.answer.mockClear();
+
+    const req = {
+      body: {
+        data: {
+          event_type: 'call.initiated',
+          payload: {
+            state: 'parked',
+            client_state: null,
+            call_control_id: 'fake_call_control_id__incoming_parked',
+            connection_id: 'fake_connection_id',
+            from: 'fake_from',
+            to: 'fake_to',
+            direction: 'incoming',
+          },
+        },
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.callControl(req, mockRes);
+
+    const callLeg = await getRepository(CallLeg).findOne({
+      from: 'fake_from',
+      to: 'fake_to',
+      direction: 'incoming',
+      telnyxCallControlId: 'fake_call_control_id__incoming_parked',
+      telnyxConnectionId: 'fake_connection_id',
+      clientCallState: 'default',
+      muted: false,
+    });
+    expect(callLeg).toBeDefined();
+    expect(telnyxMock.callMock.answer).toHaveBeenCalled();
+  });
+
+  test('handles answered new incoming calls', async () => {
+    telnyxMock.callsCreateMock.mockClear();
+    telnyxMock.conferencesCreateMock.mockClear();
+
+    const req = {
+      body: {
+        data: {
+          event_type: 'call.answered',
+          payload: {
+            client_state: encodeClientState({
+              appCallState: 'answer_incoming_parked',
+            }),
+            call_control_id: 'telnyxCallControlId1',
+            connection_id: 'fake_connection_id',
+            from: 'fake_from',
+            to: 'fake_to',
+            direction: 'incoming',
+          },
+        },
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.callControl(req, mockRes);
+
+    const conference = await getRepository(Conference).findOne({
+      where: {
+        from: 'fake_from',
+        to: 'fake_to',
+      },
+      relations: ['callLegs'],
+    });
+
+    expect(conference?.callLegs).toHaveLength(2);
+    expect(conference?.callLegs?.[0]).toEqual(
+      expect.objectContaining({
+        id: 'callLeg1',
+      })
+    );
+    expect(conference?.callLegs?.[1]).toEqual(
+      expect.objectContaining({
+        to: 'sip:agent1SipUsername@sip.telnyx.com',
+        from: 'fake_from',
+      })
+    );
+    expect(telnyxMock.callsCreateMock).toHaveBeenCalled();
+    expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
+  });
+
+  test('handles answered app dials', async () => {
+    telnyxMock.conferenceMock.join.mockClear();
+
+    const req = {
+      body: {
+        data: {
+          event_type: 'call.answered',
+          payload: {
+            client_state: encodeClientState({
+              appCallState: 'join_conference',
+              appConferenceId: 'conference3',
+            }),
+            call_control_id: 'telnyxCallControlId1',
+            connection_id: 'fake_connection_id',
+            from: 'fake_from',
+            to: 'fake_to',
+            direction: 'incoming',
+          },
+        },
+      },
+    };
+    // FIXME Better solution than ignoring dial type
+    // @ts-ignore
+    await CallsController.callControl(req, mockRes);
+
+    expect(telnyxMock.conferenceMock.join).toHaveBeenCalledWith({
+      call_control_id: 'telnyxCallControlId1',
+    });
+  });
+});

--- a/call-center/server/controllers/calls.controller.ts
+++ b/call-center/server/controllers/calls.controller.ts
@@ -142,7 +142,7 @@ class CallsController {
       await callLegRepository.save(appOutgoingCall);
 
       res.json({
-        data: appAgentCall,
+        data: appOutgoingCall,
       });
     } catch (e) {
       console.error(e);

--- a/call-center/server/fixtures/Conference.yml
+++ b/call-center/server/fixtures/Conference.yml
@@ -10,3 +10,8 @@ items:
     from: '{{phone.phoneNumber}}'
     to: '{{phone.phoneNumber}}'
     telnyxConferenceId: 'telnyxConference2'
+  conference3:
+    id: conference3
+    from: '{{phone.phoneNumber}}'
+    to: '{{phone.phoneNumber}}'
+    telnyxConferenceId: 'telnyxConference3'

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -1,8 +1,6 @@
-import { getManager } from 'typeorm';
-import { CallLeg, CallLegClientCallState } from '../entities/callLeg.entity';
+import { getRepository } from 'typeorm';
 import { Conference } from '../entities/conference.entity';
 import TestFactory from '../TestFactory';
-import { encodeClientState } from '../controllers/calls.controller';
 
 const telnyxMock = require('telnyx');
 
@@ -22,307 +20,209 @@ afterAll(async () => {
   await testFactory.close();
 });
 
-test('POST /actions/dial', () =>
-  testFactory.app
-    .post('/calls/actions/dial')
-    .send({
-      to: '+15551231234',
-      initiatorSipUsername: 'agent1SipUsername',
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const callLeg = await getManager()
-        .getRepository(CallLeg)
-        .findOne({
-          where: {
-            to: 'sip:agent1SipUsername@sip.telnyx.com',
+describe('GET /', () => {
+  test('filters results', () =>
+    testFactory.app
+      .get('/calls?telnyxCallControlId=telnyxCallControlId1')
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body.calls).toHaveLength(1);
+        expect(resp.body.calls[0]).toEqual(
+          expect.objectContaining({
+            id: 'callLeg1',
+          })
+        );
+      }));
+
+  test('limits results', () =>
+    testFactory.app
+      .get('/calls?status=active&limit=2')
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body.calls).toHaveLength(2);
+      }));
+});
+
+describe('POST /actions/dial', () => {
+  test('returns the outgoing call', () =>
+    testFactory.app
+      .post('/calls/actions/dial')
+      .send({
+        to: '+15551231234',
+        initiatorSipUsername: 'agent1SipUsername',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
             from: process.env.TELNYX_SIP_OB_NUMBER,
-            clientCallState: CallLegClientCallState.AUTO_ANSWER,
-          },
-          relations: ['conference'],
-        });
-
-      expect(callLeg).toBeDefined();
-      expect(callLeg?.conference).toBe(null);
-      expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          from: process.env.TELNYX_SIP_OB_NUMBER,
-          to: 'sip:agent1SipUsername@sip.telnyx.com',
-          connection_id: process.env.TELNYX_CC_APP_ID,
-        })
-      );
-    }));
-
-test('POST /actions/invite', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/invite')
-    .send({
-      initiatorSipUsername: 'agent1SipUsername',
-      to: 'sip:agent3SipUsername@sip.telnyx.com',
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const callLeg = await getManager()
-        .getRepository(CallLeg)
-        .findOne({
-          where: {
-            from: process.env.TELNYX_SIP_OB_NUMBER,
-            to: 'sip:agent3SipUsername@sip.telnyx.com',
-            direction: 'outgoing',
-            telnyxCallControlId: 'fake_call_control_id',
-            telnyxConnectionId: 'telnyxConnectionId1',
-            muted: false,
-          },
-          relations: ['conference'],
-        });
-
-      expect(callLeg).toBeDefined();
-      expect(callLeg?.conference?.id).toEqual('conference1');
-      expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          from: process.env.TELNYX_SIP_OB_NUMBER,
-          to: 'sip:agent3SipUsername@sip.telnyx.com',
-          connection_id: 'telnyxConnectionId1',
-        })
-      );
-    }));
-
-test('POST /actions/transfer', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/transfer')
-    .send({
-      initiatorSipUsername: 'agent1SipUsername',
-      to: 'sip:agent3SipUsername@sip.telnyx.com',
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const callLeg = await getManager()
-        .getRepository(CallLeg)
-        .findOne({
-          where: {
-            from: process.env.TELNYX_SIP_OB_NUMBER,
-            to: 'sip:agent3SipUsername@sip.telnyx.com',
-            direction: 'outgoing',
-            telnyxCallControlId: 'fake_call_control_id',
-            telnyxConnectionId: 'telnyxConnectionId1',
-            muted: false,
-          },
-          relations: ['conference'],
-        });
-
-      expect(callLeg).toBeDefined();
-      expect(callLeg?.conference?.id).toEqual('conference1');
-      expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          from: process.env.TELNYX_SIP_OB_NUMBER,
-          to: 'sip:agent3SipUsername@sip.telnyx.com',
-          connection_id: 'telnyxConnectionId1',
-        })
-      );
-      // TODO Determine which call received hangup
-      expect(telnyxMock.callMock.hangup).toHaveBeenCalled();
-    }));
-
-test('POST /actions/conferences/hangup', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/hangup')
-    .send({
-      participant: 'sip:agent1SipUsername@sip.telnyx.com',
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(() => {
-      expect(telnyxMock.callMock.hangup).toHaveBeenCalled();
-    }));
-
-test('POST /actions/conferences/mute', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/mute')
-    .send({
-      participant: 'sip:agent1SipUsername@sip.telnyx.com',
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const callLeg = await getManager()
-        .getRepository(CallLeg)
-        .findOne('callLeg2');
-
-      expect(callLeg?.muted).toEqual(true);
-      expect(telnyxMock.conferenceMock.mute).toHaveBeenCalled();
-    }));
-
-test('POST /actions/conferences/unmute', () =>
-  testFactory.app
-    .post('/calls/actions/conferences/unmute')
-    .send({
-      participant: 'sip:agent2SipUsername@sip.telnyx.com',
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const callLeg = await getManager()
-        .getRepository(CallLeg)
-        .findOne('callLeg2');
-
-      expect(callLeg?.muted).toEqual(false);
-      expect(telnyxMock.conferenceMock.unmute).toHaveBeenCalled();
-    }));
-
-test('POST /callbacks/call-control-app | call.initiated', () =>
-  testFactory.app
-    .post('/calls/callbacks/call-control-app')
-    .send({
-      data: {
-        event_type: 'call.initiated',
-        payload: {
-          state: 'parked',
-          client_state: null,
-          call_control_id: 'fake_call_control_id',
-          connection_id: 'fake_connection_id',
-          from: 'fake_from',
-          to: 'fake_to',
-          direction: 'incoming',
-        },
-      },
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const callLeg = await getManager().getRepository(CallLeg).findOne({
-        from: 'fake_from',
-        to: 'fake_to',
-        direction: 'incoming',
-        telnyxCallControlId: 'fake_call_control_id',
-        telnyxConnectionId: 'fake_connection_id',
-        muted: false,
-      });
-
-      expect(callLeg).toBeDefined();
-      expect(telnyxMock.callMock.answer).toHaveBeenCalled();
-    }));
-
-test('POST /callbacks/call-control-app | call.answered | client_state.answer_incoming_parked', () =>
-  testFactory.app
-    .post('/calls/callbacks/call-control-app')
-    .send({
-      data: {
-        event_type: 'call.answered',
-        payload: {
-          client_state: encodeClientState({
-            appCallState: 'answer_incoming_parked',
-          }),
-          call_control_id: 'telnyxCallControlId1',
-          connection_id: 'telnyxConnectionId1',
-          from: 'fake_from',
-          to: 'sip:agent1SipUsername@sip.telnyx.com',
-          direction: 'incoming',
-        },
-      },
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const conference = await getManager()
-        .getRepository(Conference)
-        .findOne({
-          where: {
-            telnyxConferenceId: 'fake_conference_id',
-            from: 'fake_from',
-          },
-          relations: ['callLegs'],
-        });
-
-      expect(conference).toBeDefined();
-      expect(conference?.callLegs).toContainEqual(
-        expect.objectContaining({
-          to: 'sip:agent1SipUsername@sip.telnyx.com',
-          direction: 'incoming',
-          telnyxCallControlId: 'telnyxCallControlId1',
-          telnyxConnectionId: 'telnyxConnectionId1',
-          status: 'active',
-        })
-      );
-      expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
-    }));
-
-test('POST /callbacks/call-control-app | call.answered | client_state.dial', () =>
-  testFactory.app
-    .post('/calls/callbacks/call-control-app')
-    .send({
-      data: {
-        event_type: 'call.answered',
-        payload: {
-          client_state: encodeClientState({
-            appCallState: 'dial',
-            appConferenceId: 'conference1',
-          }),
-          call_control_id: 'telnyxCallControlId1',
-          connection_id: 'telnyxConnectionId1',
-          from: 'fake_from',
-          to: 'sip:agent1SipUsername@sip.telnyx.com',
-          direction: 'incoming',
-        },
-      },
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(() => {
-      expect(telnyxMock.conferenceMock.join).toHaveBeenCalledWith({
-        call_control_id: 'telnyxCallControlId1',
-        start_conference_on_enter: true,
-      });
-    }));
-
-test('POST /callbacks/call-control-app | call.answered | client_state.initiate_dial', () =>
-  testFactory.app
-    .post('/calls/callbacks/call-control-app')
-    .send({
-      data: {
-        event_type: 'call.answered',
-        payload: {
-          client_state: encodeClientState({
-            appCallState: 'initiate_dial',
-            clientCallDestination: '+15551231234',
-          }),
-          call_control_id: 'telnyxCallControlId5',
-          connection_id: 'telnyxConnectionId5',
-          from: 'fake_from',
-          to: 'sip:agent1SipUsername@sip.telnyx.com',
-          direction: 'incoming',
-        },
-      },
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(async () => {
-      const conference = await getManager()
-        .getRepository(Conference)
-        .findOne({
-          where: {
-            telnyxConferenceId: 'fake_conference_id',
             to: '+15551231234',
-          },
-          relations: ['callLegs'],
-        });
+            direction: 'outgoing',
+            conference: expect.objectContaining({
+              from: 'sip:agent1SipUsername@sip.telnyx.com',
+              to: '+15551231234',
+            }),
+          })
+        );
+      }));
+});
 
-      expect(conference).toBeDefined();
-      expect(conference?.callLegs).toContainEqual(
-        expect.objectContaining({
-          to: 'sip:agent1SipUsername@sip.telnyx.com',
-          direction: 'outgoing',
-          status: 'active',
-        })
-      );
-      expect(conference?.callLegs).toContainEqual(
-        expect.objectContaining({
-          to: '+15551231234',
-          direction: 'outgoing',
-          status: 'active',
-        })
-      );
-      expect(telnyxMock.conferencesCreateMock).toHaveBeenCalled();
-    }));
+describe('POST /actions/invite', () => {
+  test('returns the outgoing call when inviting an agent', () =>
+    testFactory.app
+      .post('/calls/actions/conferences/invite')
+      .send({
+        telnyxCallControlId: 'telnyxCallControlId1',
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then(async (resp) => {
+        let expectedConference = await getRepository(Conference).findOne(
+          'conference1'
+        );
+
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
+            from: process.env.TELNYX_SIP_OB_NUMBER,
+            to: 'sip:agent3SipUsername@sip.telnyx.com',
+            direction: 'outgoing',
+            conference: expectedConference,
+          })
+        );
+      }));
+
+  test('returns the outgoing call when inviting a phone number', () =>
+    testFactory.app
+      .post('/calls/actions/conferences/invite')
+      .send({
+        telnyxCallControlId: 'telnyxCallControlId1',
+        to: '+115551231234',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then(async (resp) => {
+        let expectedConference = await getRepository(Conference).findOne(
+          'conference1'
+        );
+
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
+            from: process.env.TELNYX_SIP_OB_NUMBER,
+            to: '+115551231234',
+            direction: 'outgoing',
+            conference: expectedConference,
+          })
+        );
+      }));
+});
+
+describe('POST /actions/conferences/transfer', () => {
+  test('returns the outgoing call', () =>
+    testFactory.app
+      .post('/calls/actions/conferences/transfer')
+      .send({
+        telnyxCallControlId: 'telnyxCallControlId1',
+        to: 'sip:agent3SipUsername@sip.telnyx.com',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then(async (resp) => {
+        let expectedConference = await getRepository(Conference).findOne(
+          'conference1'
+        );
+
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
+            from: process.env.TELNYX_SIP_OB_NUMBER,
+            to: 'sip:agent3SipUsername@sip.telnyx.com',
+            direction: 'outgoing',
+            conference: expectedConference,
+          })
+        );
+      }));
+});
+
+describe('POST /actions/conferences/mute', () => {
+  test('returns the muted call', () =>
+    testFactory.app
+      .post('/calls/actions/conferences/mute')
+      .send({
+        telnyxCallControlId: 'telnyxCallControlId4',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
+            id: 'callLeg4',
+            muted: true,
+          })
+        );
+      }));
+});
+
+describe('POST /actions/conferences/unmute', () => {
+  test('returns the unmuted call', () =>
+    testFactory.app
+      .post('/calls/actions/conferences/unmute')
+      .send({
+        telnyxCallControlId: 'telnyxCallControlId2',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
+            id: 'callLeg2',
+            muted: false,
+          })
+        );
+      }));
+});
+
+describe('POST /actions/conferences/hangup', () => {
+  test('returns the ended call', () =>
+    testFactory.app
+      .post('/calls/actions/conferences/hangup')
+      .send({
+        telnyxCallControlId: 'telnyxCallControlId2',
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body.data).toEqual(
+          expect.objectContaining({
+            id: 'callLeg2',
+          })
+        );
+      }));
+});
+
+describe('POST /callbacks/call-control-app', () => {
+  test('empty response', () =>
+    testFactory.app
+      .post('/calls/callbacks/call-control-app')
+      .send({
+        data: {
+          event_type: 'call.initiated',
+          payload: {
+            state: 'parked',
+            client_state: null,
+            call_control_id: 'fake_call_control_id',
+            connection_id: 'fake_connection_id',
+            from: 'fake_from',
+            to: 'fake_to',
+            direction: 'incoming',
+          },
+        },
+      })
+      .expect('Content-type', /json/)
+      .expect(200)
+      .then((resp) => {
+        expect(resp.body).toEqual({});
+      }));
+});

--- a/call-center/server/routes/calls.test.ts
+++ b/call-center/server/routes/calls.test.ts
@@ -22,28 +22,6 @@ afterAll(async () => {
   await testFactory.close();
 });
 
-test('POST /actions/bridge', () =>
-  testFactory.app
-    .post('/calls/actions/bridge')
-    .send({
-      data: {
-        call_control_id: 'fake_call_control_id',
-        to: 'sip:agent3SipUsername@sip.telnyx.com',
-      },
-    })
-    .expect('Content-type', /json/)
-    .expect(200)
-    .then(() => {
-      expect(telnyxMock.callsCreateMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          from: process.env.TELNYX_SIP_OB_NUMBER,
-          to: 'sip:agent3SipUsername@sip.telnyx.com',
-          connection_id: process.env.TELNYX_SIP_CONNECTION_ID,
-        })
-      );
-      expect(telnyxMock.callMock.bridge).toHaveBeenCalled();
-    }));
-
 test('POST /actions/dial', () =>
   testFactory.app
     .post('/calls/actions/dial')

--- a/call-center/server/routes/conferences.test.ts
+++ b/call-center/server/routes/conferences.test.ts
@@ -19,9 +19,9 @@ afterAll(async () => {
   await testFactory.close();
 });
 
-test('GET /:id_or_sip_address', () =>
+test('GET /:telnyx_call_control_id', () =>
   testFactory.app
-    .get('/conferences/conference1')
+    .get('/conferences/telnyxCallControlId1')
     .expect('Content-type', /json/)
     .expect(200)
     .then((resp) => {


### PR DESCRIPTION
Fixes call center server tests to prepare for refactoring.

## ✋ Manual testing

Run `npm test` in `call-center/server`. Verify that all tests pass

## 📸 Screenshots
<img width="274" alt="Screen Shot 2020-10-23 at 2 44 01 PM" src="https://user-images.githubusercontent.com/4672952/97056596-3538c280-153e-11eb-94bd-4c729c1d77a1.png">
